### PR TITLE
Remove the AppInsights creation temporarily

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,12 +23,13 @@ module "key-vault" {
   create_managed_identity    = true
 }
 
+/*
 resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY" {
   name         = "AppInsightsInstrumentationKey"
   value        = azurerm_application_insights.appinsights.instrumentation_key
   key_vault_id = module.key-vault.key_vault_id
 }
-/*
+
 resource "azurerm_application_insights" "appinsights" {
   name                = "${var.product}-appinsights-${var.env}"
   location            = var.appinsights_location

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY" {
   value        = azurerm_application_insights.appinsights.instrumentation_key
   key_vault_id = module.key-vault.key_vault_id
 }
-
+/*
 resource "azurerm_application_insights" "appinsights" {
   name                = "${var.product}-appinsights-${var.env}"
   location            = var.appinsights_location
@@ -45,3 +45,4 @@ resource "azurerm_application_insights" "appinsights" {
     ]
   }
 }
+*/


### PR DESCRIPTION
Needing to get a normal build to be successful so removing the AppInsights Key look up from AKV, as it is failing.


### JIRA link (if applicable) ###
N/A


### Change description ###
Making changes to get a build working, will then fix this AKV lookup error.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
