### PR TITLE
Remove roles assigned to pre-env-mi's as they are already set (inherited)

### DIFF
--- a/ams.tf
+++ b/ams.tf
@@ -6,19 +6,24 @@ resource "azurerm_media_services_account" "ams" {
     type = "SystemAssigned, UserAssigned"
   }
 
-  managed_identity {
-    user_assigned_identity_id    = data.azurerm_user_assigned_identity.managed-identity.principal_id
-    use_system_assigned_identity = false
-  }
-
   storage_account {
     id         = module.ingestsa_storage_account.storageaccount_id
     is_primary = true
+
+    managed_identity {
+      user_assigned_identity_id    = data.azurerm_user_assigned_identity.managed-identity.principal_id
+      use_system_assigned_identity = false
+    }
   }
 
   storage_account {
     id         = module.finalsa_storage_account.storageaccount_id
     is_primary = false
+
+    managed_identity {
+      user_assigned_identity_id    = data.azurerm_user_assigned_identity.managed-identity.principal_id
+      use_system_assigned_identity = false
+    }
   }
 
   tags = var.common_tags

--- a/ams.tf
+++ b/ams.tf
@@ -2,12 +2,14 @@ resource "azurerm_media_services_account" "ams" {
   name                = "${var.product}ams${var.env}"
   location            = var.location #"UKwest"
   resource_group_name = azurerm_resource_group.rg.name
-
   identity {
-    type = "SystemAssigned"
+    type = "SystemAssigned, UserAssigned"
   }
 
-
+  managed_identity {
+    user_assigned_identity_id    = data.azurerm_user_assigned_identity.managed-identity.principal_id
+    use_system_assigned_identity = false
+  }
 
   storage_account {
     id         = module.ingestsa_storage_account.storageaccount_id

--- a/ams.tf
+++ b/ams.tf
@@ -2,28 +2,15 @@ resource "azurerm_media_services_account" "ams" {
   name                = "${var.product}ams${var.env}"
   location            = var.location #"UKwest"
   resource_group_name = azurerm_resource_group.rg.name
-  identity {
-    type = "SystemAssigned, UserAssigned"
-  }
 
   storage_account {
     id         = module.ingestsa_storage_account.storageaccount_id
     is_primary = true
-
-    managed_identity {
-      user_assigned_identity_id    = data.azurerm_user_assigned_identity.managed-identity.principal_id
-      use_system_assigned_identity = false
-    }
   }
 
   storage_account {
     id         = module.finalsa_storage_account.storageaccount_id
     is_primary = false
-
-    managed_identity {
-      user_assigned_identity_id    = data.azurerm_user_assigned_identity.managed-identity.principal_id
-      use_system_assigned_identity = false
-    }
   }
 
   tags = var.common_tags

--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "= 3.33.0"
+      version = "= 3.40.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "= 3.40.0"
+      version = "= 3.33.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/roles.tf
+++ b/roles.tf
@@ -19,6 +19,13 @@ resource "azurerm_role_assignment" "vm_user_mi" {
   skip_service_principal_aad_check = true
 }
 
+resource "azurerm_role_assignment" "pre_reader_mi" {
+  scope                            = azurerm_resource_group.rg.id
+  role_definition_name             = "Reader"
+  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id # var.pre_mi_principal_id 
+  skip_service_principal_aad_check = true
+}
+
 # Give PowerApp Appreg contributor access to resource groups
 resource "azurerm_role_assignment" "powerapp_appreg" {
   scope                = azurerm_resource_group.rg.id

--- a/roles.tf
+++ b/roles.tf
@@ -12,6 +12,13 @@ data "azuread_groups" "pre-groups" {
   display_names = ["DTS Pre-recorded Evidence"]
 }
 
+resource "azurerm_role_assignment" "vm_user_mi" {
+  scope                            = azurerm_resource_group.rg.id
+  role_definition_name             = "Virtual Machine Contributor"
+  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id # var.pre_mi_principal_id 
+  skip_service_principal_aad_check = true
+}
+
 # Give PowerApp Appreg contributor access to resource groups
 resource "azurerm_role_assignment" "powerapp_appreg" {
   scope                = azurerm_resource_group.rg.id

--- a/roles.tf
+++ b/roles.tf
@@ -12,49 +12,6 @@ data "azuread_groups" "pre-groups" {
   display_names = ["DTS Pre-recorded Evidence"]
 }
 
-#Storage Blob Data Contributor Role Assignment for Managed Identity
-resource "azurerm_role_assignment" "pre_BlobContributor_mi" {
-  scope                            = azurerm_resource_group.rg.id
-  role_definition_name             = "Storage Blob Data Contributor"
-  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id #var.pre_mi_principal_id
-  skip_service_principal_aad_check = true
-}
-
-resource "azurerm_role_assignment" "mi_storage_1" {
-  scope                            = module.ingestsa_storage_account.storageaccount_id
-  role_definition_name             = "Storage Blob Data Contributor"
-  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id #var.pre_mi_principal_id
-  skip_service_principal_aad_check = true
-}
-
-resource "azurerm_role_assignment" "mi_storage_2" {
-  scope                            = module.finalsa_storage_account.storageaccount_id
-  role_definition_name             = "Storage Blob Data Contributor"
-  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id #var.pre_mi_principal_id
-  skip_service_principal_aad_check = true
-}
-
-resource "azurerm_role_assignment" "pre_reader_mi" {
-  scope                            = azurerm_resource_group.rg.id
-  role_definition_name             = "Reader"
-  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id # var.pre_mi_principal_id 
-  skip_service_principal_aad_check = true
-}
-
-resource "azurerm_role_assignment" "vm_user_mi" {
-  scope                            = azurerm_resource_group.rg.id
-  role_definition_name             = "Virtual Machine Contributor"
-  principal_id                     = data.azurerm_user_assigned_identity.managed-identity.principal_id # var.pre_mi_principal_id 
-  skip_service_principal_aad_check = true
-}
-
-#resource "azurerm_role_assignment" "vm_user_aa" {
-#  scope                            = azurerm_resource_group.rg.id
-#  role_definition_name             = "Virtual Machine Contributor"
-#  principal_id                     = azurerm_automation_account.pre-aa.identity[0].principal_id
-#  skip_service_principal_aad_check = true
-#}
-
 # Give PowerApp Appreg contributor access to resource groups
 resource "azurerm_role_assignment" "powerapp_appreg" {
   scope                = azurerm_resource_group.rg.id


### PR DESCRIPTION
### Change description ###
they're being applied twice. the mi's have Storage Blob Data Contributor perms on the entire resource group.
They also already have contributor access so don't need to be assigned reader access as well.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
