### PR TITLE
Remove ip rules and subnets from storage accounts

### DIFF
--- a/sa-final.tf
+++ b/sa-final.tf
@@ -9,7 +9,6 @@ module "finalsa_storage_account" {
   account_replication_type        = var.sa_replication_type
   sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id], [azurerm_subnet.endpoint_subnet.id], [azurerm_subnet.datagateway_subnet.id], [azurerm_subnet.videoeditvm_subnet.id])
   allow_nested_items_to_be_public = false
-  ip_rules                        = var.ip_rules
   default_action                  = "Allow"
   enable_data_protection          = true
   restore_policy_days             = var.restore_policy_days

--- a/sa-final.tf
+++ b/sa-final.tf
@@ -7,7 +7,6 @@ module "finalsa_storage_account" {
   account_kind                    = "StorageV2"
   account_tier                    = var.sa_account_tier
   account_replication_type        = var.sa_replication_type
-  sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id], [azurerm_subnet.endpoint_subnet.id], [azurerm_subnet.datagateway_subnet.id], [azurerm_subnet.videoeditvm_subnet.id])
   allow_nested_items_to_be_public = false
   default_action                  = "Allow"
   enable_data_protection          = true

--- a/sa-ingest.tf
+++ b/sa-ingest.tf
@@ -9,7 +9,6 @@ module "ingestsa_storage_account" {
   account_replication_type        = var.sa_replication_type
   sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id], [azurerm_subnet.endpoint_subnet.id], [azurerm_subnet.datagateway_subnet.id], [azurerm_subnet.videoeditvm_subnet.id])
   allow_nested_items_to_be_public = false
-  ip_rules                        = var.ip_rules
   default_action                  = "Allow"
   enable_data_protection          = true
   restore_policy_days             = var.restore_policy_days

--- a/sa-ingest.tf
+++ b/sa-ingest.tf
@@ -7,7 +7,6 @@ module "ingestsa_storage_account" {
   account_kind                    = "StorageV2"
   account_tier                    = var.sa_account_tier
   account_replication_type        = var.sa_replication_type
-  sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id], [azurerm_subnet.endpoint_subnet.id], [azurerm_subnet.datagateway_subnet.id], [azurerm_subnet.videoeditvm_subnet.id])
   allow_nested_items_to_be_public = false
   default_action                  = "Allow"
   enable_data_protection          = true

--- a/sa-sa.tf
+++ b/sa-sa.tf
@@ -7,7 +7,6 @@ module "sa_storage_account" {
   account_kind                    = "StorageV2"
   account_tier                    = var.sa_account_tier
   account_replication_type        = var.sa_replication_type
-  sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id], [azurerm_subnet.endpoint_subnet.id], [azurerm_subnet.datagateway_subnet.id], [azurerm_subnet.videoeditvm_subnet.id])
   allow_nested_items_to_be_public = false
   default_action                  = "Deny"
   enable_data_protection          = true

--- a/sa-sa.tf
+++ b/sa-sa.tf
@@ -9,7 +9,6 @@ module "sa_storage_account" {
   account_replication_type        = var.sa_replication_type
   sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id], [azurerm_subnet.endpoint_subnet.id], [azurerm_subnet.datagateway_subnet.id], [azurerm_subnet.videoeditvm_subnet.id])
   allow_nested_items_to_be_public = false
-  ip_rules                        = var.ip_rules
   default_action                  = "Deny"
   enable_data_protection          = true
   restore_policy_days             = var.restore_policy_days

--- a/variables.tf
+++ b/variables.tf
@@ -81,12 +81,6 @@ variable "lawRetention" {
   type    = number
   default = "30"
 }
-variable "ip_rules" {
-  description = "PowerPlatformInfra.UKSouth"
-  type        = list(string)
-  default = [
-  ]
-}
 
 variable "schedules" {
   type = list(object({


### PR DESCRIPTION
the ip rules variable is already empty. we don't need to specify the subnets either as we're using private links instead.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```
