### PR TITLE
Add backups, apim

### DIFF
--- a/ams.tf
+++ b/ams.tf
@@ -101,7 +101,7 @@ resource "azurerm_private_endpoint" "ams_streamingendpoint_private_endpoint" {
   location            = var.location
   subnet_id           = data.azurerm_subnet.endpoint_subnet.id
   private_service_connection {
-    name                           = "${var.product}ams${var.env}"
+    name                           = "ams-private-link-connection"
     private_connection_resource_id = azurerm_media_services_account.ams.id
     is_manual_connection           = false
     subresource_names              = ["streamingendpoint"]
@@ -112,21 +112,3 @@ resource "azurerm_private_endpoint" "ams_streamingendpoint_private_endpoint" {
   }
   tags = var.common_tags
 }
-
-# resource "azurerm_private_endpoint" "ams_liveevent_private_endpoint" {
-#   name                = "ams-liveevent-pe-${var.env}"
-#   resource_group_name = data.azurerm_resource_group.rg.name
-#   location            = var.location
-#   subnet_id           = data.azurerm_subnet.endpoint_subnet.id
-#   private_service_connection {
-#     name                           = "ams-private-link-connection"
-#     private_connection_resource_id = azurerm_media_services_account.ams.id
-#     is_manual_connection           = false
-#     subresource_names              = ["liveevent"]
-#   }
-#   private_dns_zone_group {
-#     name                 = data.azurerm_private_dns_zone.ams_dns_zone.name
-#     private_dns_zone_ids = [data.azurerm_private_dns_zone.ams_dns_zone.id]
-#   }
-#   tags = var.common_tags
-# }

--- a/apim.tf
+++ b/apim.tf
@@ -21,6 +21,7 @@ module "ams_product" {
   subscription_required = false
 }
 
+#WIP used toffee for test purposes
 module "ams_api" {
   count          = local.env_to_deploy
   source         = "git@github.com:hmcts/cnp-module-api-mgmt-api?ref=master"
@@ -35,42 +36,3 @@ module "ams_api" {
   swagger_url    = "https://raw.githubusercontent.com/hmcts/cnp-api-docs/master/docs/specs/sds-toffee-recipes-service.json"
   content_format = "openapi+json-link"
 }
-
-# resource "azurerm_api_management_api" "api" {
-#   name                  = "${local.app_name}-${var.env}-api"
-#   resource_group_name   = "ss-${var.env}-network-rg"
-#   api_management_name   = "sds-api-mgmt-${var.env}"
-#   revision              = 1
-#   display_name          = "${local.app_name}-${var.env}-api"
-#   path                  = "${local.app_name}-${var.env}"
-#   protocols             = ["http", "https"]
-#   service_url           = "https://sds-api-mgmt-${var.env}.azure-api.net/${local.app_name}-${var.env}"
-#   subscription_required = false
-# }
-
-# data "azurerm_function_app_host_keys" "ams_keys" {
-#   name                = module.ams_function_app.function_app_name
-#   resource_group_name = azurerm_resource_group.rg.name
-# }
-
-# resource "azurerm_api_management_backend" "ams" {
-#   name                = "pre-ams-integration"
-#   resource_group_name = "ss-${var.env}-network-rg"
-#   api_management_name = "sds-api-mgmt-${var.env}"
-#   protocol            = "http"
-#   url                 = "https://${local.app_name}-${var.env}.azurewebsites.net/api/"
-
-#   credentials {
-#     header = {
-#       "x-functions-key" = "${data.azurerm_function_app_host_keys.ams_keys.default_function_key}"
-#     }
-#   }
-# }
-
-# module "ams_policy" {
-#   source        = "git@github.com:hmcts/cnp-module-api-mgmt-api-policy?ref=master"
-#   api_mgmt_name = "sds-api-mgmt-${var.env}"
-#   api_mgmt_rg   = "ss-${var.env}-network-rg"
-#   api_name      = module.ams_api.name
-#   # api_policy_xml_content = local.api_policy
-# }

--- a/apim.tf
+++ b/apim.tf
@@ -1,0 +1,76 @@
+locals {
+  app_name      = "pre-ams-integration"
+  function_name = "CheckBlobExists"
+  env_to_deploy = var.env == "sbox" ? 1 : 0
+}
+
+data "azurerm_key_vault_secret" "ams_function_key" {
+  count        = local.env_to_deploy
+  name         = "ams-function-key"
+  key_vault_id = data.azurerm_key_vault.keyvault.id
+}
+
+module "ams_product" {
+  count                 = local.env_to_deploy
+  source                = "git@github.com:hmcts/cnp-module-api-mgmt-product?ref=master"
+  api_mgmt_name         = "sds-api-mgmt-${var.env}"
+  api_mgmt_rg           = "ss-${var.env}-network-rg"
+  approval_required     = false
+  name                  = local.app_name
+  published             = true
+  subscription_required = false
+}
+
+module "ams_api" {
+  count          = local.env_to_deploy
+  source         = "git@github.com:hmcts/cnp-module-api-mgmt-api?ref=master"
+  name           = "toffee-recipes-api"
+  api_mgmt_rg    = "ss-${var.env}-network-rg"
+  api_mgmt_name  = "sds-api-mgmt-${var.env}"
+  display_name   = "toffee-recipes"
+  revision       = "1"
+  product_id     = module.ams_product[0].product_id
+  path           = "toffee-recipes-api"
+  service_url    = "http://toffee-recipe-backend-${var.env}.service.core-compute-${var.env}.internal"
+  swagger_url    = "https://raw.githubusercontent.com/hmcts/cnp-api-docs/master/docs/specs/sds-toffee-recipes-service.json"
+  content_format = "openapi+json-link"
+}
+
+# resource "azurerm_api_management_api" "api" {
+#   name                  = "${local.app_name}-${var.env}-api"
+#   resource_group_name   = "ss-${var.env}-network-rg"
+#   api_management_name   = "sds-api-mgmt-${var.env}"
+#   revision              = 1
+#   display_name          = "${local.app_name}-${var.env}-api"
+#   path                  = "${local.app_name}-${var.env}"
+#   protocols             = ["http", "https"]
+#   service_url           = "https://sds-api-mgmt-${var.env}.azure-api.net/${local.app_name}-${var.env}"
+#   subscription_required = false
+# }
+
+# data "azurerm_function_app_host_keys" "ams_keys" {
+#   name                = module.ams_function_app.function_app_name
+#   resource_group_name = azurerm_resource_group.rg.name
+# }
+
+# resource "azurerm_api_management_backend" "ams" {
+#   name                = "pre-ams-integration"
+#   resource_group_name = "ss-${var.env}-network-rg"
+#   api_management_name = "sds-api-mgmt-${var.env}"
+#   protocol            = "http"
+#   url                 = "https://${local.app_name}-${var.env}.azurewebsites.net/api/"
+
+#   credentials {
+#     header = {
+#       "x-functions-key" = "${data.azurerm_function_app_host_keys.ams_keys.default_function_key}"
+#     }
+#   }
+# }
+
+# module "ams_policy" {
+#   source        = "git@github.com:hmcts/cnp-module-api-mgmt-api-policy?ref=master"
+#   api_mgmt_name = "sds-api-mgmt-${var.env}"
+#   api_mgmt_rg   = "ss-${var.env}-network-rg"
+#   api_name      = module.ams_api.name
+#   # api_policy_xml_content = local.api_policy
+# }

--- a/backup.tf
+++ b/backup.tf
@@ -1,0 +1,26 @@
+resource "azurerm_resource_group" "rg_backup" {
+  name     = "${var.product}-${var.env}-backup"
+  location = var.location_backup
+  tags     = var.common_tags
+}
+
+resource "azurerm_data_protection_backup_vault" "pre_backup_vault" {
+  name                = "${var.product}-backup-vault-${var.env}"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = var.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+  tags                = var.common_tags
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "pre_backup_policy_storage" {
+  name               = "${var.product}-backup-policy-${var.env}"
+  vault_id           = azurerm_data_protection_backup_vault.pre_backup_vault.id
+  retention_duration = var.retention_duration
+
+  depends_on = [azurerm_media_services_account.ams]
+}
+

--- a/demo.tfvars
+++ b/demo.tfvars
@@ -10,14 +10,16 @@ mgmt_net_rg_name           = "ss-ptl-network-rg"
 mgmt_subscription_id       = "6c4d2513-a873-41b4-afdd-b05a33206631"
 
 #identites
-pre_app_admin          = "f6991ff8-d675-4f54-b2ba-99af86a8e01c"
-dts_pre_appreg_oid     = "d47c3c69-6bec-4725-ac2d-45d2c21cbd7b"
-dts_pre_ent_appreg_oid = "863c5fa3-df86-4ebc-8b0f-cd2390028497"
-pre_ent_appreg_app_id  = "14f8f054-8511-45ea-91fe-663daf87ec40"
-pre_mi_principal_id    = "d03f73e6-40ed-40a2-a0ec-059286505905" #pre-demo-mi
+pre_app_admin             = "f6991ff8-d675-4f54-b2ba-99af86a8e01c"
+dts_pre_appreg_oid        = "d47c3c69-6bec-4725-ac2d-45d2c21cbd7b"
+dts_pre_ent_appreg_oid    = "863c5fa3-df86-4ebc-8b0f-cd2390028497"
+pre_ent_appreg_app_id     = "14f8f054-8511-45ea-91fe-663daf87ec40"
+pre_mi_principal_id       = "d03f73e6-40ed-40a2-a0ec-059286505905" #pre-demo-mi
+dts_pre_backup_appreg_oid = "7716f08a-c384-4113-bf26-05a04a1f909b"
 
 #backups
-retention_duration = "P14D"
+retention_duration         = "P1D"
+immutability_period_backup = "1"
 
 #vms
 num_vid_edit_vms         = 1

--- a/dev.tfvars
+++ b/dev.tfvars
@@ -10,14 +10,15 @@ mgmt_net_rg_name           = "ss-ptl-network-rg"
 mgmt_subscription_id       = "6c4d2513-a873-41b4-afdd-b05a33206631"
 
 #identities
-pre_app_admin          = "8d48024b-9a39-4777-94b0-0751f0cb3832"
-dts_pre_ent_appreg_oid = "9168b884-7ccd-4e71-860f-7f63455818e1" # dts_pre_dev enterprise app/sp
-pre_ent_appreg_app_id  = "7394ca1a-31de-4433-beca-2ca1a2043d5c"
-
+pre_app_admin             = "8d48024b-9a39-4777-94b0-0751f0cb3832"
+dts_pre_ent_appreg_oid    = "9168b884-7ccd-4e71-860f-7f63455818e1" # dts_pre_dev enterprise app/sp
+pre_ent_appreg_app_id     = "7394ca1a-31de-4433-beca-2ca1a2043d5c"
+dts_pre_backup_appreg_oid = "7716f08a-c384-4113-bf26-05a04a1f909b"
 
 
 #backups
-retention_duration = "P8D"
+retention_duration         = "P1D"
+immutability_period_backup = "1"
 
 #vms
 num_vid_edit_vms         = 1

--- a/main.tf
+++ b/main.tf
@@ -10,22 +10,6 @@ locals {
   mgmt_network_rg_name = var.mgmt_net_rg_name
 }
 
-# resource "azurerm_role_assignment" "pre_reader_mi" {
-#   scope                            = data.azurerm_resource_group.rg.id
-#   role_definition_name             = "Reader"
-#   principal_id                     = data.azurerm_user_assigned_identity.managed_identity.principal_id # var.pre_mi_principal_id
-#   skip_service_principal_aad_check = true
-# }
-
-# resource "azurerm_role_assignment" "vm_user_mi" {
-#   scope                            = data.azurerm_resource_group.rg.id
-#   role_definition_name             = "Virtual Machine Contributor"
-#   principal_id                     = data.azurerm_user_assigned_identity.managed_identity.principal_id # var.pre_mi_principal_id
-#   skip_service_principal_aad_check = true
-# }
-
-# Give PowerApp Appreg contributor access to resource groups
-
 resource "azurerm_role_assignment" "powerapp_appreg" {
   scope                = data.azurerm_resource_group.rg.id
   role_definition_name = "Contributor"
@@ -62,15 +46,6 @@ resource "azurerm_role_assignment" "admin_sa_data_contributor" {
   principal_id         = var.pre_app_admin
 }
 
-# DTS-PRE-VideoEditing-SecurityGroup-
-# resource "azurerm_role_assignment" "vmuser_login" {
-#   for_each             = toset(data.azuread_groups.groups.object_ids)
-#   scope                = data.azurerm_resource_group.rg.id
-#   role_definition_name = "Virtual Machine User Login"
-#   principal_id         = each.value
-# }
-
-# "Contributor", "Storage Blob Data Contributor", and "User Access Administrator"
 
 resource "azurerm_automation_account" "pre-aa" {
   name                = "${var.product}-${var.env}-aa"
@@ -84,9 +59,3 @@ resource "azurerm_automation_account" "pre-aa" {
 
   tags = var.common_tags
 }
-
-# resource "azurerm_role_assignment" "kv-mi" {
-#   scope                = module.sa_storage_account.storageaccount_id
-#   role_definition_name = "Storage Account Key Operator Service Role"
-#   principal_id         = data.azuread_service_principal.kv.id
-# }

--- a/prod.tfvars
+++ b/prod.tfvars
@@ -10,15 +10,17 @@ mgmt_net_rg_name           = "ss-ptl-network-rg"
 mgmt_subscription_id       = "6c4d2513-a873-41b4-afdd-b05a33206631"
 
 #identities
-pre_app_admin          = "d5c01893-b8bc-40ce-926c-d6faf53e0af5"
-pre_mi_principal_id    = "d03f73e6-40ed-40a2-a0ec-059286505905"
-pre_mi_tenant_id       = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-dts_pre_appreg_oid     = "4f732c4d-d113-4a09-928d-6c035a26629b"
-dts_pre_ent_appreg_oid = "bec31833-3791-4d2a-80cc-871f5582f128"
-pre_ent_appreg_app_id  = "a4e4402d-25a8-40aa-ba12-ad040350086e"
+pre_app_admin             = "d5c01893-b8bc-40ce-926c-d6faf53e0af5"
+pre_mi_principal_id       = "d03f73e6-40ed-40a2-a0ec-059286505905"
+pre_mi_tenant_id          = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+dts_pre_appreg_oid        = "4f732c4d-d113-4a09-928d-6c035a26629b"
+dts_pre_ent_appreg_oid    = "bec31833-3791-4d2a-80cc-871f5582f128"
+pre_ent_appreg_app_id     = "a4e4402d-25a8-40aa-ba12-ad040350086e"
+dts_pre_backup_appreg_oid = "8cb76e1e-ef5a-41a7-9cb4-9513a48535dc"
 
 #backups
-retention_duration = "P35D"
+retention_duration         = "P100D"
+immutability_period_backup = "2557"
 
 #vms
 tenant_id                = "ebe20728"

--- a/sa-final-backup.tf
+++ b/sa-final-backup.tf
@@ -1,0 +1,55 @@
+module "finalsa_storage_account_backup" {
+  source                          = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
+  env                             = var.env
+  storage_account_name            = "${var.product}finalsabackup${var.env}"
+  resource_group_name             = azurerm_resource_group.rg_backup.name
+  location                        = var.location_backup
+  account_kind                    = "StorageV2"
+  account_tier                    = var.sa_account_tier
+  account_replication_type        = "LRS"
+  sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id])
+  allow_nested_items_to_be_public = false
+  default_action                  = "Allow"
+  enable_data_protection          = false #cannot be true as restore policy conflicts with immutability
+  immutable_enabled               = true
+  immutability_period             = var.immutability_period_backup
+
+  common_tags = var.common_tags
+}
+
+resource "azurerm_management_lock" "storage-backup-final" {
+  name       = "storage-backup"
+  scope      = module.finalsa_storage_account_backup.storageaccount_id
+  lock_level = "CanNotDelete"
+  notes      = "prevent users from deleting storage accounts"
+  depends_on = [azurerm_media_services_account.ams]
+}
+
+# Give the appreg (managed application in local directory) OID Storage Blob Data Contributor role on both the storage account and backup storage account
+resource "azurerm_role_assignment" "powerapp_appreg_final" {
+  scope                = module.finalsa_storage_account.storageaccount_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+resource "azurerm_role_assignment" "backup_role_finalsa" {
+  scope                = module.finalsa_storage_account.storageaccount_id
+  role_definition_name = "Storage Account Backup Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.pre_backup_vault.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "powerapp_appreg_finalbackup" {
+  scope                = module.finalsa_storage_account_backup.storageaccount_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "finalsabackup" {
+  name               = "${var.product}-finalsa-backup-${var.env}"
+  vault_id           = azurerm_data_protection_backup_vault.pre_backup_vault.id
+  location           = var.location
+  storage_account_id = module.finalsa_storage_account.storageaccount_id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.pre_backup_policy_storage.id
+
+  depends_on = [azurerm_role_assignment.backup_role_finalsa, module.finalsa_storage_account]
+}

--- a/sa-ingest-backup.tf
+++ b/sa-ingest-backup.tf
@@ -1,0 +1,55 @@
+module "ingestsa_storage_account_backup" {
+  source                          = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
+  env                             = var.env
+  storage_account_name            = "${var.product}ingestsabackup${var.env}"
+  resource_group_name             = azurerm_resource_group.rg_backup.name
+  location                        = var.location_backup
+  account_kind                    = "StorageV2"
+  account_tier                    = var.sa_account_tier
+  account_replication_type        = "LRS"
+  sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id])
+  allow_nested_items_to_be_public = false
+  default_action                  = "Allow"
+  enable_data_protection          = false
+  immutable_enabled               = true
+  immutability_period             = var.immutability_period_backup
+
+  common_tags = var.common_tags
+}
+
+resource "azurerm_management_lock" "storage-backup-ingest" {
+  name       = "storage-backup"
+  scope      = module.ingestsa_storage_account_backup.storageaccount_id
+  lock_level = "CanNotDelete"
+  notes      = "prevent users from deleting storage accounts"
+  depends_on = [azurerm_media_services_account.ams]
+}
+
+# Give the appreg (managed application in local directory) OID Storage Blob Data Contributor role on both the storage account and backup storage account
+resource "azurerm_role_assignment" "powerapp_appreg_ingest" {
+  scope                = module.ingestsa_storage_account.storageaccount_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+resource "azurerm_role_assignment" "powerapp_appreg_ingestfinal" {
+  scope                = module.ingestsa_storage_account_backup.storageaccount_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+resource "azurerm_role_assignment" "backup_role_ingestsa" {
+  scope                = module.ingestsa_storage_account.storageaccount_id
+  role_definition_name = "Storage Account Backup Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.pre_backup_vault.identity[0].principal_id
+}
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "ingestsabackup" {
+  name               = "${var.product}-ingestsa-backup-${var.env}"
+  vault_id           = azurerm_data_protection_backup_vault.pre_backup_vault.id
+  location           = var.location
+  storage_account_id = module.ingestsa_storage_account.storageaccount_id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.pre_backup_policy_storage.id
+
+  depends_on = [azurerm_role_assignment.backup_role_ingestsa, module.ingestsa_storage_account]
+}

--- a/sa-sa-backup.tf
+++ b/sa-sa-backup.tf
@@ -1,0 +1,60 @@
+module "sa_storage_account_backup" {
+  source                          = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
+  env                             = var.env
+  storage_account_name            = "${var.product}sabackup${var.env}"
+  resource_group_name             = azurerm_resource_group.rg_backup.name
+  location                        = var.location_backup
+  account_kind                    = "StorageV2"
+  account_tier                    = var.sa_account_tier
+  account_replication_type        = "LRS"
+  sa_subnets                      = concat([data.azurerm_subnet.jenkins_subnet.id])
+  allow_nested_items_to_be_public = false
+  default_action                  = "Allow"
+  enable_data_protection          = false
+
+  common_tags = var.common_tags
+}
+
+resource "azurerm_management_lock" "storage-backup-sa" {
+  name       = "storage-backup"
+  scope      = module.sa_storage_account_backup.storageaccount_id
+  lock_level = "CanNotDelete"
+  notes      = "prevent users from deleting storage accounts"
+  depends_on = [azurerm_media_services_account.ams]
+}
+
+# Give the appreg (managed application in local directory) OID Storage Blob Data Contributor role on both the storage account and backup storage account
+resource "azurerm_role_assignment" "powerapp_appreg_sa" {
+  scope                = module.sa_storage_account.storageaccount_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+resource "azurerm_role_assignment" "powerapp_appreg_sabackup" {
+  scope                = module.sa_storage_account_backup.storageaccount_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+# To get key and create container in backup sa storage account
+resource "azurerm_role_assignment" "powerapp_appreg_sa2" {
+  scope                = module.sa_storage_account_backup.storageaccount_id
+  role_definition_name = "Storage Account Contributor"
+  principal_id         = var.dts_pre_backup_appreg_oid
+}
+
+resource "azurerm_role_assignment" "backup_role_sa" {
+  scope                = module.sa_storage_account.storageaccount_id
+  role_definition_name = "Storage Account Backup Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.pre_backup_vault.identity[0].principal_id
+}
+
+resource "azurerm_data_protection_backup_instance_blob_storage" "sabackup" {
+  name               = "${var.product}-sa-backup-${var.env}"
+  vault_id           = azurerm_data_protection_backup_vault.pre_backup_vault.id
+  location           = var.location
+  storage_account_id = module.sa_storage_account.storageaccount_id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.pre_backup_policy_storage.id
+
+  depends_on = [azurerm_role_assignment.backup_role_sa, module.sa_storage_account]
+}

--- a/sbox.tfvars
+++ b/sbox.tfvars
@@ -10,22 +10,24 @@ mgmt_net_rg_name           = "ss-ptlsbox-network-rg"
 mgmt_subscription_id       = "64b1c6d6-1481-44ad-b620-d8fe26a2c768"
 
 #identities
-pre_app_admin          = "d055ba21-5814-4278-8752-aaffa7eaac62"
-pre_mi_principal_id    = "eb4aa503-5ffa-49ef-a69d-221e90eaf236"
-pre_mi_tenant_id       = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-dts_pre_appreg_oid     = "e3fe0d7b-10a5-4e8a-9f31-863f8618b2f4"
-dts_pre_ent_appreg_oid = "c7ee0cd6-a440-49e9-8eb8-d050a49a5962"
-pre_ent_appreg_app_id  = "07587e3c-603e-401f-98d1-ff26206e93f8"
+pre_app_admin             = "d055ba21-5814-4278-8752-aaffa7eaac62"
+pre_mi_principal_id       = "eb4aa503-5ffa-49ef-a69d-221e90eaf236"
+pre_mi_tenant_id          = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+dts_pre_appreg_oid        = "e3fe0d7b-10a5-4e8a-9f31-863f8618b2f4"
+dts_pre_ent_appreg_oid    = "c7ee0cd6-a440-49e9-8eb8-d050a49a5962"
+pre_ent_appreg_app_id     = "07587e3c-603e-401f-98d1-ff26206e93f8"
+dts_pre_backup_appreg_oid = "7716f08a-c384-4113-bf26-05a04a1f909b"
 
 #backups
-retention_duration       = "P8D"
+retention_duration         = "P1D"
+immutability_period_backup = "1"
+
+#vms
 powerbi_dg_vm_private_ip = ["10.48.1.25", "10.48.1.26"]
 dg_vm_private_ip         = ["10.48.1.22", "10.48.1.23"]
 edit_vm_private_ip       = ["10.48.1.7", "10.48.1.8"]
-
-#vms
-tenant_id        = "yrk32651"
-num_vid_edit_vms = 1
+tenant_id                = "yrk32651"
+num_vid_edit_vms         = 1
 edit_vm_data_disks = [{
   datadisk1 = {
     name                 = "edit-vm01-data-dev"

--- a/stg.tfvars
+++ b/stg.tfvars
@@ -10,18 +10,21 @@ mgmt_net_rg_name           = "ss-ptl-network-rg"
 mgmt_subscription_id       = "6c4d2513-a873-41b4-afdd-b05a33206631"
 
 #identities
-power_app_user_oid     = "2757c27a-aa98-4cdf-9aaa-90cf47d0656c"
-pre_app_admin          = "2757c27a-aa98-4cdf-9aaa-90cf47d0656c"
-pre_mi_principal_id    = "d03f73e6-40ed-40a2-a0ec-059286505905"
-pre_mi_tenant_id       = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-dts_pre_appreg_oid     = "1043d250-96eb-4cc3-af11-3215cfbf028f"
-dts_pre_ent_appreg_oid = "0f7b27ab-60b6-4682-8491-8e4eb5498dad"
-pre_ent_appreg_app_id  = "2f4bf1fd-543c-4332-bc26-7a524f52d375"
+power_app_user_oid        = "2757c27a-aa98-4cdf-9aaa-90cf47d0656c"
+pre_app_admin             = "2757c27a-aa98-4cdf-9aaa-90cf47d0656c"
+pre_mi_principal_id       = "d03f73e6-40ed-40a2-a0ec-059286505905"
+pre_mi_tenant_id          = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+dts_pre_appreg_oid        = "1043d250-96eb-4cc3-af11-3215cfbf028f"
+dts_pre_ent_appreg_oid    = "0f7b27ab-60b6-4682-8491-8e4eb5498dad"
+pre_ent_appreg_app_id     = "2f4bf1fd-543c-4332-bc26-7a524f52d375"
+dts_pre_backup_appreg_oid = "8cb76e1e-ef5a-41a7-9cb4-9513a48535dc"
 
 #backups
-retention_duration = "P35D"
+retention_duration         = "P1D"
+immutability_period_backup = "1"
 
 #vms
+tenant_id                = "yrk32651"
 num_vid_edit_vms         = 1
 powerbi_dg_vm_private_ip = ["10.101.0.24", "10.101.0.25"]
 dg_vm_private_ip         = ["10.101.0.22", "10.101.0.23"]

--- a/test.tfvars
+++ b/test.tfvars
@@ -11,18 +11,21 @@ mgmt_net_rg_name           = "ss-ptl-network-rg"
 mgmt_subscription_id       = "6c4d2513-a873-41b4-afdd-b05a33206631"
 
 #identities
-dts_pre_project_admin  = "56a29187-3d5f-4262-99d6-c635776e0eac"
-pre_app_admin          = "dbe1ceab-c6a0-4155-8f9c-060dbbbd5c2a"
-pre_mi_principal_id    = "d03f73e6-40ed-40a2-a0ec-059286505905"
-pre_mi_tenant_id       = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-dts_pre_appreg_oid     = "913743c8-60eb-4cca-a15c-2033db5118cd"
-dts_pre_ent_appreg_oid = "fd9eddbb-3ec9-4fda-81fc-d518d4718a70"
-pre_ent_appreg_app_id  = "66930c25-cbaa-4b9b-81ab-bea600666acb"
+dts_pre_project_admin     = "56a29187-3d5f-4262-99d6-c635776e0eac"
+pre_app_admin             = "dbe1ceab-c6a0-4155-8f9c-060dbbbd5c2a"
+pre_mi_principal_id       = "d03f73e6-40ed-40a2-a0ec-059286505905"
+pre_mi_tenant_id          = "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+dts_pre_appreg_oid        = "913743c8-60eb-4cca-a15c-2033db5118cd"
+dts_pre_ent_appreg_oid    = "fd9eddbb-3ec9-4fda-81fc-d518d4718a70"
+pre_ent_appreg_app_id     = "66930c25-cbaa-4b9b-81ab-bea600666acb"
+dts_pre_backup_appreg_oid = "7716f08a-c384-4113-bf26-05a04a1f909b"
 
 #backups
-retention_duration = "P35D"
+retention_duration         = "P7D"
+immutability_period_backup = "7"
 
 #vms
+tenant_id                = "yrk32651"
 powerbi_dg_vm_private_ip = ["10.70.21.25", "10.70.21.26"]
 dg_vm_private_ip         = ["10.70.21.22", "10.70.21.23"]
 edit_vm_private_ip       = ["10.70.21.6", "10.70.21.7"]

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,11 @@ variable "pre_ent_appreg_app_id" {}
 variable "aks_subscription_id" {
   default = "867a878b-cb68-4de5-9741-361ac9e178b6"
 }
+
+variable "location_backup" {
+  default = "UK West"
+}
+
+variable "dts_pre_backup_appreg_oid" {}
+
+variable "immutability_period_backup" {}

--- a/vm-datagateway.tf
+++ b/vm-datagateway.tf
@@ -9,10 +9,11 @@ module "data_gateway_vm" {
   vm_size                        = local.dg_vm_size
   vm_admin_name                  = azurerm_key_vault_secret.dg_username[count.index].value
   vm_admin_password              = azurerm_key_vault_secret.dg_password[count.index].value
-  vm_availabilty_zones           = local.dg_vm_availabilty_zones[count.index]
+  vm_availabilty_zones           = local.dg_vm_availability_zones[count.index]
   managed_disks                  = var.dg_vm_data_disks[count.index]
   accelerated_networking_enabled = true
   custom_data                    = filebase64("./scripts/datagateway-init.ps1")
+  privateip_allocation           = "Static"
 
   #Disk Encryption
   kv_name     = var.env == "prod" ? "${var.product}-hmctskv-${var.env}" : "${var.product}-${var.env}"
@@ -110,7 +111,7 @@ locals {
 
   dg_vm_subnet_id = data.azurerm_subnet.datagateway_subnet.id
 
-  dg_vm_availabilty_zones  = [1, 2]
+  dg_vm_availability_zones = [1, 2]
   dg_marketplace_product   = "WindowsServer"
   dg_marketplace_publisher = "MicrosoftWindowsServer"
   dg_marketplace_sku       = "2019-Datacenter-gensecond"

--- a/vm-edit.tf
+++ b/vm-edit.tf
@@ -9,10 +9,11 @@ module "edit_vm" {
   vm_size                        = local.edit_vm_size
   vm_admin_name                  = azurerm_key_vault_secret.edit_username[count.index].value
   vm_admin_password              = azurerm_key_vault_secret.edit_password[count.index].value
-  vm_availabilty_zones           = local.edit_vm_availabilty_zones[count.index]
+  vm_availabilty_zones           = local.edit_vm_availability_zones[count.index]
   managed_disks                  = var.edit_vm_data_disks[count.index]
   accelerated_networking_enabled = true
   custom_data                    = filebase64("./scripts/edit-init.ps1")
+  privateip_allocation           = "Static"
 
   #Disk Encryption
   kv_name     = var.env == "prod" ? "${var.product}-hmctskv-${var.env}" : "${var.product}-${var.env}"
@@ -59,7 +60,7 @@ locals {
 
   edit_vm_subnet_id = data.azurerm_subnet.videoedit_subnet.id
 
-  edit_vm_availabilty_zones  = [1, 2]
+  edit_vm_availability_zones = [1, 2]
   edit_marketplace_product   = "Windows-10"
   edit_marketplace_publisher = "MicrosoftWindowsDesktop"
   edit_marketplace_sku       = "20h1-pro-g2"

--- a/vm-powerbi-dg.tf
+++ b/vm-powerbi-dg.tf
@@ -9,9 +9,10 @@ module "powerBI_data_gateway" {
   vm_size                        = local.powerbi_dg_vm_size
   vm_admin_name                  = azurerm_key_vault_secret.powerbi_dg_username[count.index].value
   vm_admin_password              = azurerm_key_vault_secret.powerbi_dg_password[count.index].value
-  vm_availabilty_zones           = local.powerbi_dg_vm_availabilty_zones[count.index]
+  vm_availabilty_zones           = local.powerbi_dg_vm_availability_zones[count.index]
   managed_disks                  = var.powerbi_dg_vm_data_disks[count.index]
   accelerated_networking_enabled = true
+  privateip_allocation           = "Static"
   # custom_data                    = filebase64("./scripts/datagateway-init.ps1")
 
   #Disk Encryption
@@ -89,7 +90,7 @@ locals {
 
   powerbi_dg_vm_subnet_id = data.azurerm_subnet.datagateway_subnet.id
 
-  powerbi_dg_vm_availabilty_zones  = [1, 2]
+  powerbi_dg_vm_availability_zones = [1, 2]
   powerbi_dg_marketplace_product   = "WindowsServer"
   powerbi_dg_marketplace_publisher = "MicrosoftWindowsServer"
   powerbi_dg_marketplace_sku       = "2019-Datacenter-gensecond"


### PR DESCRIPTION
- Make Dev Happen
- pipeline changes
- add dev.tfvars
- one more var
- resource not data
- update roles
- depends on
- forgot something
- try
- test hard coding dev as subscription
- Set up CI with Azure Pipelines
- Upgrade AMS
- Uncomment hub
- increase timeout
- plain
- depends
- subnets
- vars
- vars
- vars
- moe
- more
- stg
- rejiggle
- rejiggle
- refactor sa's
- refactor
- refactor
- refactor
- jenkins
- set var for dev
- update ams
- update stg.tfvars
- update dynatrace module
- update dynatrace module
- update safinal to use new flag
- update safinal to use new flag
- Use dev subscription
- Use approved branch
- Try bump terraform version
- Disable private endpoint for now
- Fix build
- move out network stage
- move out network stage
- data
- rm depends_on encruption null_resource
- rm hub provider
- amend Jenkinsfile
- data rg
- data rg
- data rg
- data rg
- jenkins perms
- jenkins perms
- jenkins perms
- naming
- remove key vault
- shorter name vm
- rm backups, shorter vm names
- rm sa settings temp
- temp changes
- add sa logs, dg module
- module call
- module call
- modules
- just vms
- add sbox config
- add pre-commit, update readme
- make edit vm a module
- fix
- move creds in
- diff pip
- diff pip
- shorter names
- new fields
- jenkins
- jenkins
- vars
- vars
- better names
- try extensions
- try extensions
- try extensions
- try extensions
- try extensions
- try extensions
- try extensions
- try extensions
- try extensions
- try null resource
- try extension with file already loaded on machine
- add custom_data, rm extensions temporarily
- forgot one
- add edit extension
- try again
- try with a uri
- not try dg
- function module
- function module
- no .
- source
- source
- source again
- source again
- source again
- try agin
- now with tags
- now with tags
- no zone balancing
- comment out
- comment out
- comment out
- count
- count
- count
- count
- count
- upgrade provider
- add file  workaround
- remove file  workaround
- remove language
- add windows fa
- add windows fa
- add windows fa
- comment out
- comment out
- linux again
- private endpoints ams + finalsa
- module call
- add subresoruce names
- add subresoruce names
- only 1 subresoruce allowed
- add backups module
- add backups module
- dev vars
- add contributer perms
- add contributer perms
- add more ams app config
- add more ams app config
- add more ams app config
- add more ams app config
- add perms to admin and app reg
- add perms to admin and app reg
- add perms to sub
- rm perms to sub
- add v2 auth settings
- rm v2 auth settings
- ams uami
- ams uami
- ams uami
- update provider
- back to system
- back to 3.37
- roll back
- roll back
- perms
- removing some comments
- move back to sbox admin
- move back to sbox admin
- update providers
- amend local module source to include .git
- dev admin perms
- another dev admin perms
- add config values
- do not expire
- can't pre-pop field
- change function app settings
- change function app settings
- add app insights, authentication
- spare var
- env var
- env var
- zc function app
- zc storage account
- zc storage account
- zc storage account
- add new storage accounts as part of module
- add new storage accounts as part of module
- add new storage accounts as part of module
- add new storage accounts as part of module
- add new storage accounts as part of module
- no auth settings
- no app settings
- try add site_config
- correct backups module to not use data source
- add vars
- add vars
- add vm vars to all envs
- vault
- sa name
- temp no module
- add backup vault
- letters only sa
- upgrade azurerm to 3.38.0
- make backup instance GR, back to 3.37.0
- Add funciton app settings
- No sa key
- add values
- add subscription id value
- add zc test function
- amend app insights name for function apps
- add power bi vm
- rename module
- set to sds
- some extras
- ids
- change naming
- rm dg extension
- rename disk
- rename powerbi dg
- add timestamp function app, rm zc function app
- fix
- shorter name for sa's
- add env to function app name
- add env to function app name
- Adding dependency on storage account for backup protection
- first draft
- update vnetpeering
- Update vnet.tf
- Remove old unused code
- Adding storage account contrib role for spn to create container in backup sa storage account
- Adding storage account contrib role for spn to create container in backup sa storage account
- rm ps1 file
- Adding access for backup SPN to get keys and enumerate storage account
- Changing role for backup SPN to list containers in sa storage account
- Add nsg
- Add tags
- rm tag
- Reverting role assignment for sa storage account
- Changing storage module retention policy to test pitr setting
- Changing retention policy to 2d to see if it applies correctly
- Adding value for pitr to storage module
- Adding value for pitr to storage module
- Adding value for pitr to storage module to all storage accounts for testing
- Turning off data protection on backup storage accounts with immutability enabled due to conflicting settings
- Turning off data protection on backup storage accounts with immutability enabled due to conflicting settings
- Adding pitr value for all environs
- Add APIM API
- Changing back to master on storage module as code now merged
- use local
- feature flag to only deploy to sbox
- feature flag to only deploy to sbox
- element
- add key
- add flag to key
- service url
- try with backend
- try different swagger url
- try null path
- try different service url, path
- try different path
- try different path
- trying
- try different name
- try different path
- try branch
- try with empty swagger
- back to master
- test with toffee
- tidying
- Remove unused vnet peering module
- Enable private endpoints for AMS and storage
- add field
- add zone block
- remove comment
- 1 subresource
- Add AMS private endpoint
- correct fields
- point to branch
- point to branch for all sa's
- Add AMS App Settings
- Add AMS App Settings
- Add AMS App Settings
- fix: update terraform vm module reference
- fix: update terraform vm module reference
- fix: correct variable names
- rename module for edit and dg as well
- Add env vars to stay in sync
- Add env vars to stay in sync
- Add env vars to stay in sync
- put var back
- vm kv names
- remove some vm module fields
- put back
- Remove unused fields from vm module
- Remove IP rules
- Remove sa subnets
- Remove sa subnets and ip rules
- Add zone link to ams endpoint
- Add zone link to ams endpoint
- add retention days to sa metrics
- Add code owners
- Add code owners
- Add zone link for ams
- Better variable naming
- add zone link and better variable naming
- typo
- corrent
- add endpoint for live events
- add endpoint for live events
- rm sa sa from private endpoint subnet
- add back streaming endpoint pe
- better name
- re-enable sa sa endpoint
- Change private link zone id
- Upgrade terraform version
- Tidy up files
- Tidy up files
- update SKUs for dev
- update SKUs for dev
- add new computer_name field to vm module
- Add new computer_name field to vm module
- Add azure cli to edit vm script
- No private endpoint for live events
- remove exampledata
- remove functionapp-video.tf
- update Jenkinsfile_CNP
- update Jenkinsfile_CNP
- fix
- ams connection name change
- add backups, apim,

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
