### PR TITLE
Add a new db for the api to use

### DIFF
--- a/postgres.tf
+++ b/postgres.tf
@@ -15,6 +15,9 @@ module "data_store_db_v14" {
   pgsql_databases = [
     {
       name : "pre-pdb-${var.env}"
+    },
+    {
+      name : "api"
     }
   ]
 


### PR DESCRIPTION
I'd rather make a new db than just a new schema for this as I want to keep the db names consistent throughout the environments (server name contains the env). I've confirmed this with the rest of the team.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
