### PR TITLE
Use platops naming convention for db credentials

### DIFF
--- a/postgres.tf
+++ b/postgres.tf
@@ -33,6 +33,29 @@ module "data_store_db_v14" {
 
 }
 
+# @todo remove once we have switched PowerApps to use the API
+resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
+  name         = "postgresdb-host"
+  value        = module.data_store_db_v14.fqdn
+  key_vault_id = data.azurerm_key_vault.keyvault.id
+}
+
+# @todo remove once we have switched PowerApps to use the API
+resource "azurerm_key_vault_secret" "POSTGRES_USER" {
+  name         = "postgresdb-username"
+  value        = var.pgsql_admin_username
+  key_vault_id = data.azurerm_key_vault.keyvault.id
+}
+
+#https://github.com/hmcts/terraform-module-postgresql-flexible/blob/master/outputs.tf
+# @todo remove once we have switched PowerApps to use the API
+resource "azurerm_key_vault_secret" "POSTGRES_PASS" {
+  name         = "postgresdb-password"
+  value        = module.data_store_db_v14.password
+  key_vault_id = data.azurerm_key_vault.keyvault.id
+}
+
+# Needed by the Common Pipeline db migration step
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
   name         = "api-POSTGRES-HOST"
   value        = module.data_store_db_v14.fqdn

--- a/postgres.tf
+++ b/postgres.tf
@@ -34,20 +34,34 @@ module "data_store_db_v14" {
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
-  name         = "postgresdb-host"
+  name         = "api-POSTGRES-HOST"
   value        = module.data_store_db_v14.fqdn
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }
 
+# Not returned by the module outputs but needed for the pipeline migration step so hardcoding
+resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
+  name         = "api-POSTGRES-PORT"
+  value        = "5432"
+  key_vault_id = data.azurerm_key_vault.keyvault.id
+}
+
+# Not returned by the module outputs but needed for the pipeline migration step so hardcoding
+resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
+  name         = "api-POSTGRES-DATABASE"
+  value        = "api"
+  key_vault_id = data.azurerm_key_vault.keyvault.id
+}
+
 resource "azurerm_key_vault_secret" "POSTGRES_USER" {
-  name         = "postgresdb-username"
+  name         = "api-POSTGRES-USER"
   value        = var.pgsql_admin_username
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }
 
 #https://github.com/hmcts/terraform-module-postgresql-flexible/blob/master/outputs.tf
 resource "azurerm_key_vault_secret" "POSTGRES_PASS" {
-  name         = "postgresdb-password"
+  name         = "api-POSTGRES-PASS"
   value        = module.data_store_db_v14.password
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }

--- a/postgres.tf
+++ b/postgres.tf
@@ -56,34 +56,34 @@ resource "azurerm_key_vault_secret" "POSTGRES_PASS" {
 }
 
 # Needed by the Common Pipeline db migration step
-resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
+resource "azurerm_key_vault_secret" "API_POSTGRES_HOST" {
   name         = "api-POSTGRES-HOST"
   value        = module.data_store_db_v14.fqdn
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }
 
 # Not returned by the module outputs but needed for the pipeline migration step so hardcoding
-resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
+resource "azurerm_key_vault_secret" "API_POSTGRES_PORT" {
   name         = "api-POSTGRES-PORT"
   value        = "5432"
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }
 
 # Not returned by the module outputs but needed for the pipeline migration step so hardcoding
-resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
+resource "azurerm_key_vault_secret" "API_POSTGRES_DATABASE" {
   name         = "api-POSTGRES-DATABASE"
   value        = "api"
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }
 
-resource "azurerm_key_vault_secret" "POSTGRES_USER" {
+resource "azurerm_key_vault_secret" "API_POSTGRES_USER" {
   name         = "api-POSTGRES-USER"
   value        = var.pgsql_admin_username
   key_vault_id = data.azurerm_key_vault.keyvault.id
 }
 
 #https://github.com/hmcts/terraform-module-postgresql-flexible/blob/master/outputs.tf
-resource "azurerm_key_vault_secret" "POSTGRES_PASS" {
+resource "azurerm_key_vault_secret" "API_POSTGRES_PASS" {
   name         = "api-POSTGRES-PASS"
   value        = module.data_store_db_v14.password
   key_vault_id = data.azurerm_key_vault.keyvault.id


### PR DESCRIPTION
Keeping old entries too as used in PowerApps pipelines. Have added a todo to remove once we switch to the new API

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
