### PR TITLE
Modify title in b2c login page

### DIFF
--- a/b2c/login.html
+++ b/b2c/login.html
@@ -35,7 +35,7 @@
     <div class="govuk-header__content">
 
       <a href="https://pre-portal.staging.platform.hmcts.net/view-option" class="govuk-header__link govuk-header__link--service-name">
-        PRE
+        Pre-Recorded Evidence Service
       </a>
 
 


### PR DESCRIPTION
### Change description ###
so it says our service name in full

<img width="839" alt="Screenshot 2024-02-22 at 10 37 54" src="https://github.com/hmcts/pre-shared-infrastructure/assets/54357991/4601ae78-f695-4033-9a40-6a322eba2dd7">

