### PR TITLE
Call js on dom load only. Remove prod references

### DIFF
--- a/b2c/custom_policies/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/TrustFrameworkExtensions.xml
@@ -24,7 +24,7 @@
         </Metadata>
       </ContentDefinition>
       <ContentDefinition Id="api.idpselections.signup">
-        <LoadUri>https://presaprod.blob.core.windows.net/pre-b2c-container/login.html</LoadUri>
+        <LoadUri>https://presastg.blob.core.windows.net/pre-b2c-container/login.html</LoadUri>
         <RecoveryUri>~/common/default_page_error.html</RecoveryUri>
         <DataUri>urn:com:microsoft:aad:b2c:elements:contract:providerselection:1.2.1</DataUri>
         <Metadata>
@@ -33,7 +33,7 @@
         </Metadata>
       </ContentDefinition>
       <ContentDefinition Id="api.signuporsignin">
-        <LoadUri>https://presaprod.blob.core.windows.net/pre-b2c-container/login.html</LoadUri>
+        <LoadUri>https://presastg.blob.core.windows.net/pre-b2c-container/login.html</LoadUri>
         <RecoveryUri>~/common/default_page_error.html</RecoveryUri>
         <DataUri>urn:com:microsoft:aad:b2c:elements:contract:unifiedssp:2.1.5</DataUri>
         <Metadata>
@@ -57,7 +57,7 @@
         </Metadata>
       </ContentDefinition>
       <ContentDefinition Id="api.localaccountsignup">
-        <LoadUri>https://presaprod.blob.core.windows.net/pre-b2c-container/login.html</LoadUri>
+        <LoadUri>https://presastg.blob.core.windows.net/pre-b2c-container/login.html</LoadUri>
         <RecoveryUri>~/common/default_page_error.html</RecoveryUri>
         <DataUri>urn:com:microsoft:aad:b2c:elements:contract:selfasserted:2.1.7</DataUri>
         <Metadata>

--- a/b2c/login.html
+++ b/b2c/login.html
@@ -8,14 +8,35 @@
   <meta name="theme-color" content="#0b0c0c">
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="https://presastg.blob.core.windows.net/pre-b2c-container/favicon.ico"
         type="image/x-icon">
+  <link href="https://presastg.blob.core.windows.net/pre-b2c-container/login.css" rel="stylesheet">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <script type="application/javascript">
+    function moveForgotPassword() {
+      const forgotPasswordId = 'forgotPassword'
+      const forgotPassword = document.getElementById(forgotPasswordId);
+
+      if (forgotPassword) {
+        const text = forgotPassword.innerHTML;
+        forgotPassword.remove();
+
+        const newForgotPassword = document.createElement('a');
+        newForgotPassword.id = forgotPasswordId;
+        newForgotPassword.innerHTML = text;
+
+        const div = document.createElement('div');
+        div.className = 'forgotPassword-wrapper';
+        div.appendChild(newForgotPassword);
+
+        const passwordInput = document.getElementById('password');
+        passwordInput.parentNode.insertBefore(div, passwordInput.nextSibling);
+      }
+    }
+  </script>
 </head>
-<body>
+<body onload="moveForgotPassword();">
 <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-
 <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
 
 <header class="govuk-header " role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
@@ -69,7 +90,6 @@
 
   <main class="govuk-main-wrapper " id="main-content" role="main">
 
-    <link href="https://presastg.blob.core.windows.net/pre-b2c-container/login.css" rel="stylesheet">
     <div class="row">
       <div class="col1">
         <div id="api">
@@ -77,9 +97,6 @@
       </div>
       <div class="col2">
       </div>
-    </div>
-
-
     </div>
 
   </main>
@@ -165,30 +182,6 @@
     </div>
   </div>
 </footer>
-
-<script>
-  function moveForgotPassword() {
-    const forgotPasswordId = 'forgotPassword'
-    const forgotPassword = document.getElementById(forgotPasswordId);
-
-    if (forgotPassword) {
-      const text = forgotPassword.innerHTML;
-      forgotPassword.remove();
-
-      const newForgotPassword = document.createElement('a');
-      newForgotPassword.id = forgotPasswordId;
-      newForgotPassword.innerHTML = text;
-
-      const div = document.createElement('div');
-      div.className = 'forgotPassword-wrapper';
-      div.appendChild(newForgotPassword);
-
-      const passwordInput = document.getElementById('password');
-      passwordInput.parentNode.insertBefore(div, passwordInput.nextSibling);
-    }
-  }
-  moveForgotPassword();
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
I don't _think_ these should point to prod? I'm hoping we can template for all envs though??

The js onload thing may solve any issues in rendering if js goes wonky like it seemingly has today? worth a shot I felt.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
