### PR TITLE
Limits signups to set number of email tlds

### DIFF
--- a/b2c/custom_policies/SignUpOrSignin.xml
+++ b/b2c/custom_policies/SignUpOrSignin.xml
@@ -3,6 +3,26 @@
     <TenantId>hmctsdevextid.onmicrosoft.com</TenantId>
     <PolicyId>B2C_1A_TrustFrameworkExtensions</PolicyId>
   </BasePolicy>
+
+  <BuildingBlocks>
+    <ClaimsSchema>
+      <ClaimType Id="email">
+        <Restriction>
+          <Pattern RegularExpression="^[a-zA-Z0-9.!#$%&amp;'^_`{}~\-]+@(justice\.gov\.uk|hmcts\.net|ejudiciary\.net|.\.cjsm\.net|cps\.gov\.uk)" HelpText="Please enter a email address from one of the following domains: outlook.com, live.com." />
+        </Restriction>
+      </ClaimType>
+    </ClaimsSchema>
+
+    <Localization>
+      <LocalizedResources Id="api.localaccountsignup.en">
+        <LocalizedStrings>
+          <LocalizedString ElementType="ClaimType" ElementId="email" StringId="PatternHelpText">Please enter a email address from one of the following domains: outlook.com, live.com, or gmail.com.</LocalizedString>
+        </LocalizedStrings>
+      </LocalizedResources>
+    </Localization>
+
+  </BuildingBlocks>
+
   <RelyingParty>
     <DefaultUserJourney ReferenceId="SignUpOrSignIn" />
     <Endpoints>

--- a/b2c/custom_policies/SignUpOrSignin.xml
+++ b/b2c/custom_policies/SignUpOrSignin.xml
@@ -8,7 +8,7 @@
     <ClaimsSchema>
       <ClaimType Id="email">
         <Restriction>
-          <Pattern RegularExpression="^[a-zA-Z0-9.!#$%&amp;'^_`{}~\-]+@(justice\.gov\.uk|hmcts\.net|ejudiciary\.net|.\.cjsm\.net|cps\.gov\.uk)" HelpText="Please enter a email address from one of the following domains: outlook.com, live.com." />
+          <Pattern RegularExpression="^[a-zA-Z0-9.!#$%&amp;'^_`{}~\-]+@(justice\.gov\.uk|hmcts\.net|ejudiciary\.net|.\.cjsm\.net|cps\.gov\.uk)" HelpText="Please enter a email address from one of the following domains: justice.gov.uk, hmcts.net, ejudiciary.net, .cjsm.net, cps.gov.uk." />
         </Restriction>
       </ClaimType>
     </ClaimsSchema>


### PR DESCRIPTION
### Change description ###

Have applied the following regex https://regexper.com/#%5E%5Ba-zA-Z0-9.!%23%24%25%26amp%3B'%5E_%60%7B%7D~%5C-%5D%2B%40%28justice%5C.gov%5C.uk%7Chmcts%5C.net%7Cejudiciary%5C.net%7C.%5C.cjsm%5C.net%7Ccps%5C.gov%5C.uk%29 to cover these domains:
@[justice.gov.uk](http://justice.gov.uk/)
@[hmcts.net](http://hmcts.net/)
@[ejudiciary.net](http://ejudiciary.net/)
@*.[cjsm.net](http://cjsm.net/)
@[cps.gov.uk](http://cps.gov.uk/)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
