### PR TITLE
Style tweaks

### DIFF
--- a/b2c/b2c_injection_reference/mfa-resend.html
+++ b/b2c/b2c_injection_reference/mfa-resend.html
@@ -1,0 +1,37 @@
+<div id="api" data-name="Phonefactor" role="form">
+  <span id="screen_reader_msg" role="alert" aria-label="" aria-hidden="true" style="display:none"></span>
+  <div class="buttons">
+  </div>
+  <div class="intro">
+    <p>We have the following number on record for you. We can send a code via SMS or phone to authenticate you.</p>
+  </div>
+  <div class="error pageLevel" id="errorMessage" style="display:none" aria-hidden="true">
+    <p role="alert">The verification code you have entered does not match our records. Please try again, or request a new code.</p>
+  </div>
+
+  <div class="phoneNumbers" id="phoneNumbers">
+    <div class="phoneNumber">
+      <div class="type">Phone Number</div>
+      <div class="number">XXX-XXX-46784</div>
+    </div>
+  </div>
+
+  <div id="codeVerification" style="display: block;" aria-hidden="false">
+    <div class="actionLabel" aria-hidden="false" style="display: block;">
+      <label for="verificationCode">Enter your verification code below, or </label>
+      <a id="retryCode" tabindex="1">send a new code</a>
+    </div>
+    <div class="error itemLevel" aria-hidden="true" style="display: none;">
+      <p role="alert"></p>
+    </div>
+    <input type="text" role="textbox" id="verificationCode" maxlength="6" autocomplete="false" pattern="\d{6}" title="Please enter the verification code you received" aria-required="true" aria-hidden="false" style="display: block;">
+  </div>
+
+  <div class="working" style="display: none;"></div>
+
+  <div class="buttons">
+    <button id="sendCode" autofocus="" class="disabled" aria-disabled="true" style="display: none;">Send Code</button><button id="verifyCode" class="disabled" aria-disabled="true" style="display: inline-block;">Verify Code</button><button id="verifyPhone" class="disabled" aria-disabled="true" style="display: none;">Call Me</button><button id="continuePhone" class="disabled" aria-disabled="true" style="display: none;">Continue</button>
+    <button id="cancel">Cancel</button>
+  </div>
+
+</div>

--- a/b2c/views/css/main.css
+++ b/b2c/views/css/main.css
@@ -21,7 +21,8 @@
   font-display: fallback;
 }
 .govuk-link,
-#api a {
+#api a,
+#api #retryCode {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -31,12 +32,14 @@
 }
 @media print {
   .govuk-link,
-  #api a {
+  #api a,
+  #api #retryCode  {
     font-family: sans-serif;
   }
 }
 .govuk-link:hover,
-#api a:hover {
+#api a:hover,
+#api #retryCode:hover {
   text-decoration-thickness: max(3px, .1875rem, .12em);
   -webkit-text-decoration-skip-ink: none;
   text-decoration-skip-ink: none;
@@ -44,7 +47,8 @@
   text-decoration-skip: none;
 }
 .govuk-link:focus,
-#api a:focus {
+#api a:focus,
+#api #retryCode:focus {
   outline: 3px solid transparent;
   color: #0b0c0c;
   background-color: #ffdd00;
@@ -54,23 +58,29 @@
   box-decoration-break: clone;
 }
 .govuk-link:link,
-#api a:link {
+#api a:link,
+#api #retryCode:link,
+#api #retryCode {
   color: #1d70b8;
 }
 .govuk-link:visited,
-#api a:visited {
+#api a:visited,
+#api #retryCode:visited {
   color: #4c2c92;
 }
 .govuk-link:hover,
-#api a:hover {
+#api a:hover,
+#api #retryCode:hover {
   color: #003078;
 }
 .govuk-link:active,
-#api a:active {
+#api a:active,
+#api #retryCode:active {
   color: #0b0c0c;
 }
 .govuk-link:focus,
-#api a:focus {
+#api a:focus,
+#api #retryCode:focus {
   color: #0b0c0c;
 }
 @media print {
@@ -214,7 +224,7 @@
 }
 @media (min-width: 40.0625em) {
   .govuk-list--bullet > li,
-.govuk-list--number > li {
+  .govuk-list--number > li {
     margin-bottom: 5px;
   }
 }
@@ -662,8 +672,8 @@
 }
 @media (min-width: 40.0625em) {
   .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l,
-.govuk-body-s + .govuk-heading-l,
-.govuk-list + .govuk-heading-l {
+  .govuk-body-s + .govuk-heading-l,
+  .govuk-list + .govuk-heading-l {
     padding-top: 20px;
   }
 }
@@ -679,12 +689,12 @@
 }
 @media (min-width: 40.0625em) {
   .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m,
-.govuk-body-s + .govuk-heading-m,
-.govuk-list + .govuk-heading-m,
-.govuk-body-m + .govuk-heading-s,
-.govuk-body + .govuk-heading-s,
-.govuk-body-s + .govuk-heading-s,
-.govuk-list + .govuk-heading-s {
+  .govuk-body-s + .govuk-heading-m,
+  .govuk-list + .govuk-heading-m,
+  .govuk-body-m + .govuk-heading-s,
+  .govuk-body + .govuk-heading-s,
+  .govuk-body-s + .govuk-heading-s,
+  .govuk-list + .govuk-heading-s {
     padding-top: 10px;
   }
 }
@@ -789,7 +799,7 @@
   }
 }
 .govuk-button-group .govuk-button,
-  #api .buttons button {
+#api .buttons button {
   margin-bottom: 17px;
 }
 @media (min-width: 40.0625em) {
@@ -1001,7 +1011,7 @@
 }
 @media (min-width: 40.0625em) {
   .govuk-main-wrapper--auto-spacing:first-child,
-.govuk-main-wrapper--l {
+  .govuk-main-wrapper--l {
     padding-top: 50px;
   }
 }
@@ -1373,17 +1383,17 @@
 }
 @media screen and (forced-colors: active) {
   .govuk-frontend-supported .govuk-accordion__show-all:hover .govuk-accordion-nav__chevron,
-.govuk-frontend-supported .govuk-accordion__section-button:hover .govuk-accordion-nav__chevron {
+  .govuk-frontend-supported .govuk-accordion__section-button:hover .govuk-accordion-nav__chevron {
     background-color: transparent;
   }
   .govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion__section-heading-text-focus,
-.govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion__section-summary-focus,
-.govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion__section-toggle-focus,
-.govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion-nav__chevron,
-.govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion__section-heading-text-focus,
-.govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion__section-summary-focus,
-.govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion__section-toggle-focus,
-.govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion-nav__chevron {
+  .govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion__section-summary-focus,
+  .govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion__section-toggle-focus,
+  .govuk-frontend-supported .govuk-accordion__show-all:focus .govuk-accordion-nav__chevron,
+  .govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion__section-heading-text-focus,
+  .govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion__section-summary-focus,
+  .govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion__section-toggle-focus,
+  .govuk-frontend-supported .govuk-accordion__section-button:focus .govuk-accordion-nav__chevron {
     background: transparent;
     background-color: transparent;
   }
@@ -1676,7 +1686,8 @@
   border-color: currentcolor;
 }
 .govuk-button,
-#api button {
+#api button,
+#api #email_ver_but_send {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -1703,64 +1714,77 @@
   -webkit-appearance: none;
 }
 @media print {
-  .govuk-button, #api button {
+  .govuk-button, #api button,
+  #api #email_ver_but_send {
     font-family: sans-serif;
   }
 }
 @media (min-width: 40.0625em) {
-  .govuk-button, #api button {
+  .govuk-button, #api button,
+  #api #email_ver_but_send {
     font-size: 1.1875rem;
     line-height: 1;
   }
 }
 @media print {
-  .govuk-button, #api button {
+  .govuk-button, #api button,
+  #api #email_ver_but_send {
     font-size: 14pt;
     line-height: 19px;
   }
 }
 @media (min-width: 40.0625em) {
-  .govuk-button, #api button {
+  .govuk-button, #api button,
+  #api #email_ver_but_send {
     margin-bottom: 32px;
   }
 }
 @media (min-width: 40.0625em) {
-  .govuk-button, #api button {
+  .govuk-button, #api button,
+  #api #email_ver_but_send {
     width: auto;
   }
 }
-.govuk-button:link, .govuk-button:visited, .govuk-button:active, .govuk-button:hover, #api button:link, #api button:visited, #api button:active, #api button:hover {
+.govuk-button:link, .govuk-button:visited, .govuk-button:active, .govuk-button:hover,
+#api button:link, #api button:visited, #api button:active, #api button:hover,
+#api #email_ver_but_send:link, #api #email_ver_but_send:visited, #api #email_ver_but_send:active, #api #email_ver_but_send:hover {
   color: #ffffff;
   text-decoration: none;
 }
 .govuk-button::-moz-focus-inner,
-#api button::-moz-focus-inner {
+#api button::-moz-focus-inner,
+#api #email_ver_but_send::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
 .govuk-button:hover,
-#api button:hover {
+#api button:hover,
+#api #email_ver_but_send:hover {
   background-color: #005a30;
 }
 .govuk-button:active,
-#api button:active {
+#api button:active,
+#api #email_ver_but_send:active {
   top: 2px;
 }
 .govuk-button:focus,
-#api button:focus {
+#api button:focus,
+#api #email_ver_but_send:focus {
   border-color: #ffdd00;
   outline: 3px solid transparent;
   box-shadow: inset 0 0 0 1px #ffdd00;
 }
 .govuk-button:focus:not(:active):not(:hover),
-#api button:focus:not(:active):not(:hover) {
+#api button:focus:not(:active):not(:hover),
+#api #email_ver_but_send:focus:not(:active):not(:hover) {
   border-color: #ffdd00;
   color: #0b0c0c;
   background-color: #ffdd00;
   box-shadow: 0 2px 0 #0b0c0c;
 }
 .govuk-button::before,
-#api button::before {
+#api button::before,
+#api #email_ver_but_send::before {
   content: "";
   display: block;
   position: absolute;
@@ -1771,21 +1795,25 @@
   background: transparent;
 }
 .govuk-button:active::before,
-#api button:active::before {
+#api button:active::before,
+#api #email_ver_but_send:active::before {
   top: -4px;
 }
 
 .govuk-button[disabled],
-#api button[disabled] {
+#api button[disabled],
+#api #email_ver_but_send[disabled] {
   opacity: 0.5;
 }
 .govuk-button[disabled]:hover,
-#api button[disabled]:hover {
+#api button[disabled]:hover,
+#api #email_ver_but_send[disabled]:hover {
   background-color: #00703c;
   cursor: not-allowed;
 }
 .govuk-button[disabled]:active,
-#api button[disabled]:active {
+#api button[disabled]:active,
+#api #email_ver_but_send[disabled]:active {
   top: 0;
   box-shadow: 0 2px 0 #002d18;
 }
@@ -2148,7 +2176,7 @@
 
 @supports not (caret-color: auto) {
   .govuk-fieldset,
-x:-moz-any-link {
+  x:-moz-any-link {
     display: table-cell;
   }
 }
@@ -2513,13 +2541,13 @@ x:-moz-any-link {
   }
 }
 .govuk-input:focus,
-  #api input:focus {
+#api input:focus {
   outline: 3px solid #ffdd00;
   outline-offset: 0;
   box-shadow: inset 0 0 0 2px;
 }
 .govuk-input:disabled,
-  #api input:disabled {
+#api input:disabled {
   opacity: 0.5;
   color: inherit;
   background-color: transparent;
@@ -2620,27 +2648,27 @@ x:-moz-any-link {
 }
 @media print {
   .govuk-input__prefix,
-.govuk-input__suffix {
+  .govuk-input__suffix {
     font-family: sans-serif;
   }
 }
 @media (min-width: 40.0625em) {
   .govuk-input__prefix,
-.govuk-input__suffix {
+  .govuk-input__suffix {
     font-size: 1.1875rem;
     line-height: 1.3157894737;
   }
 }
 @media print {
   .govuk-input__prefix,
-.govuk-input__suffix {
+  .govuk-input__suffix {
     font-size: 14pt;
     line-height: 1.15;
   }
 }
 @media (max-width: 19.99em) {
   .govuk-input__prefix,
-.govuk-input__suffix {
+  .govuk-input__suffix {
     display: block;
     height: 100%;
     white-space: normal;
@@ -2845,7 +2873,7 @@ x:-moz-any-link {
   }
 }
 .govuk-error-summary,
-  #api .error + .pageLevel {
+#api .error + .pageLevel {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -2896,7 +2924,7 @@ x:-moz-any-link {
   }
 }
 .govuk-error-summary:focus,
-  #api .error + .pageLevel:focus {
+#api .error + .pageLevel:focus {
   outline: 3px solid #ffdd00;
 }
 
@@ -3986,23 +4014,23 @@ x:-moz-any-link {
 }
 @media print {
   .govuk-pagination__item,
-.govuk-pagination__next,
-.govuk-pagination__prev {
+  .govuk-pagination__next,
+  .govuk-pagination__prev {
     font-family: sans-serif;
   }
 }
 @media (min-width: 40.0625em) {
   .govuk-pagination__item,
-.govuk-pagination__next,
-.govuk-pagination__prev {
+  .govuk-pagination__next,
+  .govuk-pagination__prev {
     font-size: 1.1875rem;
     line-height: 1.3157894737;
   }
 }
 @media print {
   .govuk-pagination__item,
-.govuk-pagination__next,
-.govuk-pagination__prev {
+  .govuk-pagination__next,
+  .govuk-pagination__prev {
     font-size: 14pt;
     line-height: 1.15;
   }
@@ -4851,8 +4879,8 @@ x:-moz-any-link {
 }
 @media (min-width: 40.0625em) {
   .govuk-summary-list__key,
-.govuk-summary-list__value,
-.govuk-summary-list__actions {
+  .govuk-summary-list__value,
+  .govuk-summary-list__actions {
     display: table-cell;
     padding-top: 10px;
     padding-right: 20px;
@@ -4945,8 +4973,8 @@ x:-moz-any-link {
 }
 @media (min-width: 40.0625em) {
   .govuk-summary-list--no-border .govuk-summary-list__key,
-.govuk-summary-list--no-border .govuk-summary-list__value,
-.govuk-summary-list--no-border .govuk-summary-list__actions {
+  .govuk-summary-list--no-border .govuk-summary-list__value,
+  .govuk-summary-list--no-border .govuk-summary-list__actions {
     padding-bottom: 11px;
   }
 }
@@ -4956,8 +4984,8 @@ x:-moz-any-link {
 }
 @media (min-width: 40.0625em) {
   .govuk-summary-list__row--no-border .govuk-summary-list__key,
-.govuk-summary-list__row--no-border .govuk-summary-list__value,
-.govuk-summary-list__row--no-border .govuk-summary-list__actions {
+  .govuk-summary-list__row--no-border .govuk-summary-list__value,
+  .govuk-summary-list__row--no-border .govuk-summary-list__actions {
     padding-bottom: 11px;
   }
 }
@@ -7260,4 +7288,7 @@ input[type="checkbox"] {
 #attributeVerification #attributeList {
   border-bottom: 1px solid #b1b4b6;
   margin-bottom: 25px;
+}
+#api #retryCode {
+  cursor: pointer;
 }

--- a/b2c/views/template.html
+++ b/b2c/views/template.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 
-    <link rel="stylesheet" href="./css/main.css">
+    <link rel="stylesheet" href="https://presastg.blob.core.windows.net/pre-b2c-container/css/main.css">
 
     <link rel="manifest" href="https://presastg.blob.core.windows.net/pre-b2c-container/assets/manifest.json">
     <link rel="icon" sizes="48x48" href="https://presastg.blob.core.windows.net/pre-b2c-container/assets/images/favicon.ico">

--- a/b2c/views/template.html
+++ b/b2c/views/template.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 
-    <link rel="stylesheet" href="https://presastg.blob.core.windows.net/pre-b2c-container/css/main.css">
+    <link rel="stylesheet" href="./css/main.css">
 
     <link rel="manifest" href="https://presastg.blob.core.windows.net/pre-b2c-container/assets/manifest.json">
     <link rel="icon" sizes="48x48" href="https://presastg.blob.core.windows.net/pre-b2c-container/assets/images/favicon.ico">
@@ -35,6 +35,24 @@
           passwordInput.parentNode.insertBefore(div, passwordInput.nextSibling);
         }
       }
+      function moveRetryCode() {
+        const retryCode = document.getElementById('retryCode');
+
+        if (retryCode) {
+          const text = retryCode.innerHTML;
+          retryCode.remove();
+
+          const newRetryCode = document.createElement('a');
+          newRetryCode.id = 'retryCode';
+          newRetryCode.innerHTML = text;
+
+          const div = document.createElement('div');
+          div.appendChild(newRetryCode);
+
+          const verificationCodeInput = document.getElementById('verificationCode');
+          verificationCodeInput.parentNode.insertBefore(div, verificationCodeInput.nextSibling);
+        }
+      }
 
       function addTsAndCsLink() {
         const tsAndCsBlock = document.getElementsByClassName('CheckboxMultiSelect')[0];
@@ -50,7 +68,7 @@
       }
     </script>
   </head>
-  <body class="govuk-template__body" onload="moveForgotPassword();addTsAndCsLink();">
+  <body class="govuk-template__body" onload="moveForgotPassword();moveRetryCode();addTsAndCsLink();">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>


### PR DESCRIPTION
### Change description ###
Sets send code button to be primary styled on the signup page
Gives link style to the resend code link on mfa page as there is no href attribute supplied by ms
Added js to move the resent code link below the input box

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
