### PR TITLE
Fix B2C js running on dom ready

### DIFF
--- a/b2c/views/js/b2c.js
+++ b/b2c/views/js/b2c.js
@@ -49,8 +49,7 @@ function addTsAndCsLink() {
     }
   }
 }
-
-document.addEventListener("DOMContentLoaded", function(e) {
+$(function() {
   moveForgotPassword();
   moveRetryCode();
   addTsAndCsLink();


### PR DESCRIPTION
### Change description ###
I couldn't get this working using conventional onload methods. This works using the custom version of jquery MS load into B2C. It works because the script is included in the template with the `defer` attribute. If `async` is used it will yield varying results due to a potential race condition with jquery loading but as it stands this is safe and works (tested a manually change in the SA)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
