### PR TITLE
B2c cancel button

### DIFF
--- a/b2c/custom_policies/demo/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkBase.xml
@@ -823,6 +823,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.socialccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -863,6 +864,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.selfasserted.profileupdate</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -903,6 +905,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -944,6 +947,7 @@
             <Item Key="setting.operatingMode">Email</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignin</Item>
             <Item Key="IncludeClaimResolvingInClaimsHandling">true</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -976,6 +980,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1003,6 +1008,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1042,6 +1048,9 @@
             Name="Proprietary"
             Handler="Web.TPEngine.SSO.DefaultSSOSessionProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
           />
+          <Metadata>
+            <Item Key="setting.showCancelButton">false</Item>
+          </Metadata>
           <PersistedClaims>
             <PersistedClaim ClaimTypeReferenceId="objectId" />
             <PersistedClaim ClaimTypeReferenceId="signInName" />

--- a/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
@@ -139,6 +139,7 @@
           <TechnicalProfile Id="SelfAsserted-LocalAccountSignin-Email">
             <Metadata>
               <Item Key="setting.forgotPasswordLinkOverride">ForgotPasswordExchange</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <OutputClaimsTransformations>
               <OutputClaimsTransformation ReferenceId="CopySignInNameToReadOnly" />
@@ -226,6 +227,7 @@
           />
             <Metadata>
               <Item Key="ContentDefinitionReferenceId">api.selfasserted</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="readOnlyEmail" />

--- a/b2c/custom_policies/dev/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkBase.xml
@@ -823,6 +823,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.socialccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -863,6 +864,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.selfasserted.profileupdate</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -903,6 +905,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -944,6 +947,7 @@
             <Item Key="setting.operatingMode">Email</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignin</Item>
             <Item Key="IncludeClaimResolvingInClaimsHandling">true</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -976,6 +980,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1003,6 +1008,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1042,6 +1048,9 @@
             Name="Proprietary"
             Handler="Web.TPEngine.SSO.DefaultSSOSessionProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
           />
+          <Metadata>
+            <Item Key="setting.showCancelButton">false</Item>
+          </Metadata>
           <PersistedClaims>
             <PersistedClaim ClaimTypeReferenceId="objectId" />
             <PersistedClaim ClaimTypeReferenceId="signInName" />

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -139,6 +139,7 @@
           <TechnicalProfile Id="SelfAsserted-LocalAccountSignin-Email">
             <Metadata>
               <Item Key="setting.forgotPasswordLinkOverride">ForgotPasswordExchange</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <OutputClaimsTransformations>
               <OutputClaimsTransformation ReferenceId="CopySignInNameToReadOnly" />
@@ -226,6 +227,7 @@
           />
             <Metadata>
               <Item Key="ContentDefinitionReferenceId">api.selfasserted</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="readOnlyEmail" />

--- a/b2c/custom_policies/prod/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkBase.xml
@@ -823,6 +823,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.socialccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -863,6 +864,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.selfasserted.profileupdate</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -903,6 +905,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -944,6 +947,7 @@
             <Item Key="setting.operatingMode">Email</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignin</Item>
             <Item Key="IncludeClaimResolvingInClaimsHandling">true</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -976,6 +980,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1003,6 +1008,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1042,6 +1048,9 @@
             Name="Proprietary"
             Handler="Web.TPEngine.SSO.DefaultSSOSessionProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
           />
+          <Metadata>
+            <Item Key="setting.showCancelButton">false</Item>
+          </Metadata>
           <PersistedClaims>
             <PersistedClaim ClaimTypeReferenceId="objectId" />
             <PersistedClaim ClaimTypeReferenceId="signInName" />

--- a/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
@@ -139,6 +139,7 @@
           <TechnicalProfile Id="SelfAsserted-LocalAccountSignin-Email">
             <Metadata>
               <Item Key="setting.forgotPasswordLinkOverride">ForgotPasswordExchange</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <OutputClaimsTransformations>
               <OutputClaimsTransformation ReferenceId="CopySignInNameToReadOnly" />
@@ -226,6 +227,7 @@
           />
             <Metadata>
               <Item Key="ContentDefinitionReferenceId">api.selfasserted</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="readOnlyEmail" />

--- a/b2c/custom_policies/stg/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkBase.xml
@@ -823,6 +823,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.socialccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -863,6 +864,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.selfasserted.profileupdate</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -903,6 +905,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -944,6 +947,7 @@
             <Item Key="setting.operatingMode">Email</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignin</Item>
             <Item Key="IncludeClaimResolvingInClaimsHandling">true</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -976,6 +980,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1003,6 +1008,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1042,6 +1048,9 @@
             Name="Proprietary"
             Handler="Web.TPEngine.SSO.DefaultSSOSessionProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
           />
+          <Metadata>
+            <Item Key="setting.showCancelButton">false</Item>
+          </Metadata>
           <PersistedClaims>
             <PersistedClaim ClaimTypeReferenceId="objectId" />
             <PersistedClaim ClaimTypeReferenceId="signInName" />

--- a/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
@@ -139,6 +139,7 @@
           <TechnicalProfile Id="SelfAsserted-LocalAccountSignin-Email">
             <Metadata>
               <Item Key="setting.forgotPasswordLinkOverride">ForgotPasswordExchange</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <OutputClaimsTransformations>
               <OutputClaimsTransformation ReferenceId="CopySignInNameToReadOnly" />
@@ -226,6 +227,7 @@
           />
             <Metadata>
               <Item Key="ContentDefinitionReferenceId">api.selfasserted</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="readOnlyEmail" />

--- a/b2c/custom_policies/test/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/test/TrustFrameworkBase.xml
@@ -823,6 +823,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.socialccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -863,6 +864,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.selfasserted.profileupdate</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -903,6 +905,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignup</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -944,6 +947,7 @@
             <Item Key="setting.operatingMode">Email</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountsignin</Item>
             <Item Key="IncludeClaimResolvingInClaimsHandling">true</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaims>
@@ -976,6 +980,7 @@
           <Metadata>
             <Item Key="IpAddressClaimReferenceId">IpAddress</Item>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1003,6 +1008,7 @@
           />
           <Metadata>
             <Item Key="ContentDefinitionReferenceId">api.localaccountpasswordreset</Item>
+            <Item Key="setting.showCancelButton">false</Item>
           </Metadata>
           <CryptographicKeys>
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
@@ -1042,6 +1048,9 @@
             Name="Proprietary"
             Handler="Web.TPEngine.SSO.DefaultSSOSessionProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
           />
+          <Metadata>
+            <Item Key="setting.showCancelButton">false</Item>
+          </Metadata>
           <PersistedClaims>
             <PersistedClaim ClaimTypeReferenceId="objectId" />
             <PersistedClaim ClaimTypeReferenceId="signInName" />

--- a/b2c/custom_policies/test/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/test/TrustFrameworkExtensions.xml
@@ -139,6 +139,7 @@
           <TechnicalProfile Id="SelfAsserted-LocalAccountSignin-Email">
             <Metadata>
               <Item Key="setting.forgotPasswordLinkOverride">ForgotPasswordExchange</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <OutputClaimsTransformations>
               <OutputClaimsTransformation ReferenceId="CopySignInNameToReadOnly" />
@@ -226,6 +227,7 @@
           />
             <Metadata>
               <Item Key="ContentDefinitionReferenceId">api.selfasserted</Item>
+              <Item Key="setting.showCancelButton">false</Item>
             </Metadata>
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="readOnlyEmail" />


### PR DESCRIPTION
### Change description ###

Azure B2C throws an error whenever a 'Cancel' button is pressed. Documentation suggests it is meant to pass this error to the callback url for the app to handle but our app is not seeing this callback and B2C is throwing the error on it's own page.

This PR removes all Cancel buttons from the UI .... "fixed"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
