### PR TITLE
S28-2666/forgotten password journey broken

### DIFF
--- a/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
@@ -294,6 +294,10 @@
               <Value>647ef962-b03f-40fa-b9a0-df5243bc8334</Value> <!-- assume automated test user has valid phone -->
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>isForgotPassword</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -281,24 +281,30 @@
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
             </Preconditions>
+            <ClaimsExchanges>
+              <ClaimsExchange
+                Id="SignUpWithLogonEmailExchange"
+                TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmail"
+              />
+            </ClaimsExchanges>
             <JourneyList>
               <Candidate SubJourneyReferenceId="PasswordReset" />
             </JourneyList>
           </OrchestrationStep>
 
-        <!-- This step forces email verification on sign in only. -->
-        <OrchestrationStep Order="4" Type="ClaimsExchange">
-          <Preconditions>
-            <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
-              <Value>objectId</Value>
-              <Value>cd2ef111-05a1-41b7-a576-f2f05a6ffcd0</Value> <!-- assume automated test user has valid phone -->
-              <Action>SkipThisOrchestrationStep</Action>
-            </Precondition>
-          </Preconditions>
-          <ClaimsExchanges>
-            <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />
-          </ClaimsExchanges>
-        </OrchestrationStep>
+          <!-- This step forces email verification on sign in only. -->
+          <OrchestrationStep Order="4" Type="ClaimsExchange">
+            <Preconditions>
+              <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                <Value>objectId</Value>
+                <Value>cd2ef111-05a1-41b7-a576-f2f05a6ffcd0</Value> <!-- assume automated test user has valid phone -->
+                <Action>SkipThisOrchestrationStep</Action>
+              </Precondition>
+            </Preconditions>
+            <ClaimsExchanges>
+              <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />
+            </ClaimsExchanges>
+          </OrchestrationStep>
 
           <!-- Show self-asserted page only if the directory does not have the user account already (i.e. we do not have an objectId).
             This can only happen when authentication happened using a social IDP. If local account was created or authentication done
@@ -364,9 +370,13 @@
           <OrchestrationStep Order="1" Type="ClaimsExchange">
             <ClaimsExchanges>
               <ClaimsExchange
-              Id="PasswordResetUsingEmailAddressExchange"
-              TechnicalProfileReferenceId="LocalAccountDiscoveryUsingEmailAddress"
-            />
+                Id="PasswordResetUsingEmailAddressExchange"
+                TechnicalProfileReferenceId="LocalAccountDiscoveryUsingEmailAddress"
+              />
+              <ClaimsExchange
+                Id="SignUpWithLogonEmailExchange"
+                TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmail"
+              />
             </ClaimsExchanges>
           </OrchestrationStep>
 
@@ -374,9 +384,13 @@
           <OrchestrationStep Order="2" Type="ClaimsExchange">
             <ClaimsExchanges>
               <ClaimsExchange
-              Id="NewCredentials"
-              TechnicalProfileReferenceId="LocalAccountWritePasswordUsingObjectId"
-            />
+                Id="NewCredentials"
+                TechnicalProfileReferenceId="LocalAccountWritePasswordUsingObjectId"
+              />
+              <ClaimsExchange
+                Id="SignUpWithLogonEmailExchange"
+                TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmail"
+              />
             </ClaimsExchanges>
           </OrchestrationStep>
         </OrchestrationSteps>

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -281,7 +281,6 @@
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
             </Preconditions>
-
             <JourneyList>
               <Candidate SubJourneyReferenceId="PasswordReset" />
             </JourneyList>
@@ -369,9 +368,9 @@
           <OrchestrationStep Order="1" Type="ClaimsExchange">
             <ClaimsExchanges>
               <ClaimsExchange
-                Id="PasswordResetUsingEmailAddressExchange"
-                TechnicalProfileReferenceId="LocalAccountDiscoveryUsingEmailAddress"
-              />
+              Id="PasswordResetUsingEmailAddressExchange"
+              TechnicalProfileReferenceId="LocalAccountDiscoveryUsingEmailAddress"
+            />
             </ClaimsExchanges>
           </OrchestrationStep>
 
@@ -379,9 +378,9 @@
           <OrchestrationStep Order="2" Type="ClaimsExchange">
             <ClaimsExchanges>
               <ClaimsExchange
-                Id="NewCredentials"
-                TechnicalProfileReferenceId="LocalAccountWritePasswordUsingObjectId"
-              />
+              Id="NewCredentials"
+              TechnicalProfileReferenceId="LocalAccountWritePasswordUsingObjectId"
+            />
             </ClaimsExchanges>
           </OrchestrationStep>
         </OrchestrationSteps>

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -295,6 +295,10 @@
                 <Value>cd2ef111-05a1-41b7-a576-f2f05a6ffcd0</Value> <!-- assume automated test user has valid phone -->
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
+              <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                <Value>isForgotPassword</Value>
+                <Action>SkipThisOrchestrationStep</Action>
+              </Precondition>
             </Preconditions>
             <ClaimsExchanges>
               <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />
@@ -380,7 +384,6 @@
               />
             </ClaimsExchanges>
           </OrchestrationStep>
-          <OrchestrationStep Order="3" Type="SendClaims" CpimIssuerTechnicalProfileReferenceId="UserInfoIssuer" />
         </OrchestrationSteps>
       </SubJourney>
     </SubJourneys>

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -281,12 +281,7 @@
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
             </Preconditions>
-            <ClaimsExchanges>
-              <ClaimsExchange
-                Id="SignUpWithLogonEmailExchange"
-                TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmail"
-              />
-            </ClaimsExchanges>
+
             <JourneyList>
               <Candidate SubJourneyReferenceId="PasswordReset" />
             </JourneyList>
@@ -373,10 +368,6 @@
                 Id="PasswordResetUsingEmailAddressExchange"
                 TechnicalProfileReferenceId="LocalAccountDiscoveryUsingEmailAddress"
               />
-              <ClaimsExchange
-                Id="SignUpWithLogonEmailExchange"
-                TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmail"
-              />
             </ClaimsExchanges>
           </OrchestrationStep>
 
@@ -387,12 +378,9 @@
                 Id="NewCredentials"
                 TechnicalProfileReferenceId="LocalAccountWritePasswordUsingObjectId"
               />
-              <ClaimsExchange
-                Id="SignUpWithLogonEmailExchange"
-                TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmail"
-              />
             </ClaimsExchanges>
           </OrchestrationStep>
+          <OrchestrationStep Order="3" Type="SendClaims" CpimIssuerTechnicalProfileReferenceId="UserInfoIssuer" />
         </OrchestrationSteps>
       </SubJourney>
     </SubJourneys>

--- a/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
@@ -294,6 +294,10 @@
               <Value>ea7978c4-da9a-42ae-ad9e-c5a93e7fa46d</Value> <!-- assume automated test user has valid phone -->
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>isForgotPassword</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
@@ -294,6 +294,10 @@
               <Value>a207a1b2-f39b-4e70-a211-bd7e26d7504e</Value> <!-- assume automated test user has valid phone -->
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>isForgotPassword</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/test/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/test/TrustFrameworkExtensions.xml
@@ -294,6 +294,10 @@
               <Value>3c04187a-0a25-4a60-8666-66d29d41ceb6</Value> <!-- assume automated test user has valid phone -->
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>isForgotPassword</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/views/css/main.css
+++ b/b2c/views/css/main.css
@@ -7309,3 +7309,6 @@ input[type="checkbox"] {
 #api #retryCode {
   cursor: pointer;
 }
+.changeClaims {
+  visibility: hidden;
+}


### PR DESCRIPTION
### Change description ###
Prevents the forgotten login journey from asking a user to verify their email account twice when signing in

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
