### PR TITLE
S28 2673/double email verify

### DIFF
--- a/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
@@ -298,6 +298,10 @@
               <Value>isForgotPassword</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>TnCs</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -298,8 +298,8 @@
                 <Value>isForgotPassword</Value>
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
-              <Precondition Type="ClaimsExist" ExecuteActionsIf="true"><!-- TnCs -->
-                <Value>Verified.Email</Value>
+              <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                <Value>TnCs</Value>
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
             </Preconditions>

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -298,6 +298,10 @@
                 <Value>isForgotPassword</Value>
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
+              <Precondition Type="ClaimsExist" ExecuteActionsIf="true"><!-- TnCs -->
+                <Value>Verified.Email</Value>
+                <Action>SkipThisOrchestrationStep</Action>
+              </Precondition>
             </Preconditions>
             <ClaimsExchanges>
               <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
@@ -298,6 +298,10 @@
               <Value>isForgotPassword</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>TnCs</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
@@ -298,6 +298,10 @@
               <Value>isForgotPassword</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>TnCs</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />

--- a/b2c/custom_policies/test/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/test/TrustFrameworkExtensions.xml
@@ -298,6 +298,10 @@
               <Value>isForgotPassword</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
+            <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+              <Value>TnCs</Value>
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
           </Preconditions>
           <ClaimsExchanges>
             <ClaimsExchange Id="EmailVerifyOnSignIn" TechnicalProfileReferenceId="EmailVerifyOnSignIn" />


### PR DESCRIPTION
### Change description ###
During signup people have to verify their email, then again then they got to the login segment. This PR skips this last stage for new signups by checking if the TnCs claim is present


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
