### PR TITLE
Remove display name

### DIFF
--- a/b2c/custom_policies/demo/SignUpOrSignin.xml
+++ b/b2c/custom_policies/demo/SignUpOrSignin.xml
@@ -54,9 +54,9 @@
       <DisplayName>PolicyProfile</DisplayName>
       <Protocol Name="OpenIdConnect" />
       <OutputClaims>
-        <OutputClaim ClaimTypeReferenceId="displayName" />
-        <OutputClaim ClaimTypeReferenceId="givenName" />
-        <OutputClaim ClaimTypeReferenceId="surname" />
+<!--        <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="surname" />-->
         <OutputClaim ClaimTypeReferenceId="email" />
         <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />

--- a/b2c/custom_policies/demo/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkBase.xml
@@ -612,9 +612,9 @@
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="oid" />
             <OutputClaim ClaimTypeReferenceId="tenantId" PartnerClaimType="tid" />
-            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />
-            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />
-            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />-->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="upn" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="localAccountAuthentication" />
           </OutputClaims>
@@ -659,7 +659,7 @@
             <!-- Required claims -->
             <PersistedClaim ClaimTypeReferenceId="email" PartnerClaimType="signInNames.emailAddress" />
             <PersistedClaim ClaimTypeReferenceId="newPassword" PartnerClaimType="password" />
-            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />
+<!--            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />-->
             <PersistedClaim ClaimTypeReferenceId="passwordPolicies" DefaultValue="DisablePasswordExpiration" />
 
             <PersistedClaim
@@ -668,8 +668,8 @@
             />
 
             <!-- Optional claims. -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" />
@@ -700,7 +700,7 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="accountEnabled" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
@@ -757,8 +757,8 @@
             />
 
             <!-- Optional claims -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -780,10 +780,10 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="otherMails" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -834,9 +834,9 @@
                  these values, or if the claim did not appear in the OutputClaims section of the IDP.
                  In addition, if a claim is not in the InputClaims section, but it is in the OutputClaims section, then its
                  value will not be prefilled, but the user will still be prompted for it (with an empty value). -->
-            <InputClaim ClaimTypeReferenceId="displayName" />
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- These claims are not shown to the user because their value is obtained through the "ValidationTechnicalProfiles"
@@ -849,9 +849,9 @@
             <!-- Optional claims. These claims are collected from the user and can be modified. If a claim is to be persisted in the directory after having been
                  collected from the user, it needs to be added as a PersistedClaim in the ValidationTechnicalProfile referenced below, i.e.
                  in AAD-UserWriteUsingAlternativeSecurityId. -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <UseTechnicalProfileForSessionManagement ReferenceId="SM-SocialSignup" />
         </TechnicalProfile>
@@ -873,8 +873,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- Required claims -->
@@ -882,8 +882,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteProfileUsingObjectId" />
@@ -923,9 +923,9 @@
             <OutputClaim ClaimTypeReferenceId="newUser" />
 
             <!-- Optional claims, to be collected from the user -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" />-->
 
             <OutputClaim ClaimTypeReferenceId="TnCs" Required="true" />
           </OutputClaims>
@@ -1167,7 +1167,7 @@
       <TechnicalProfile Id="AAD-UserReadUsingObjectId-CheckRefreshTokenDate">
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="refreshTokensValidFromDateTime" />
-          <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--          <OutputClaim ClaimTypeReferenceId="displayName" />-->
         </OutputClaims>
         <OutputClaimsTransformations>
           <OutputClaimsTransformation ReferenceId="AssertRefreshTokenIssuedLaterThanValidFromDate" />

--- a/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkExtensions.xml
@@ -164,9 +164,9 @@
             <!-- The Below claims are what will be returned on the UserInfo Endpoint if in the Claims Bag-->
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="objectId" />
-              <InputClaim ClaimTypeReferenceId="givenName" />
-              <InputClaim ClaimTypeReferenceId="surname" />
-              <InputClaim ClaimTypeReferenceId="displayName" />
+<!--              <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--              <InputClaim ClaimTypeReferenceId="surname" />-->
+<!--              <InputClaim ClaimTypeReferenceId="displayName" />-->
               <InputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             </InputClaims>
           </TechnicalProfile>

--- a/b2c/custom_policies/demo/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkLocalization.xml
@@ -75,7 +75,7 @@
           <LocalizedString
             ElementType="UxElement"
             StringId="local_intro_generic"
-          >Sign in with your {0}</LocalizedString>
+          >Sign in</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="password"
@@ -175,12 +175,12 @@
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="DisplayName"
-          >New Password</LocalizedString>
+          >Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="UserHelpText"
-          >Enter new password</LocalizedString>
+          >Enter password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
@@ -190,12 +190,12 @@
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="DisplayName"
-          >Confirm New Password</LocalizedString>
+          >Confirm Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="UserHelpText"
-          >Confirm new password</LocalizedString>
+          >Confirm password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"

--- a/b2c/custom_policies/dev/SignUpOrSignin.xml
+++ b/b2c/custom_policies/dev/SignUpOrSignin.xml
@@ -55,8 +55,8 @@
       <Protocol Name="OpenIdConnect" />
       <OutputClaims>
         <OutputClaim ClaimTypeReferenceId="displayName" />
-        <OutputClaim ClaimTypeReferenceId="givenName" />
-        <OutputClaim ClaimTypeReferenceId="surname" />
+<!--        <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="surname" />-->
         <OutputClaim ClaimTypeReferenceId="email" />
         <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />

--- a/b2c/custom_policies/dev/SignUpOrSignin.xml
+++ b/b2c/custom_policies/dev/SignUpOrSignin.xml
@@ -54,7 +54,7 @@
       <DisplayName>PolicyProfile</DisplayName>
       <Protocol Name="OpenIdConnect" />
       <OutputClaims>
-        <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--        <OutputClaim ClaimTypeReferenceId="displayName" />-->
 <!--        <OutputClaim ClaimTypeReferenceId="givenName" />-->
 <!--        <OutputClaim ClaimTypeReferenceId="surname" />-->
         <OutputClaim ClaimTypeReferenceId="email" />

--- a/b2c/custom_policies/dev/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkBase.xml
@@ -311,7 +311,7 @@
         <UserInputType>CheckboxMultiSelect</UserInputType>
         <Restriction>
           <Enumeration
-            Text="I agree to the Terms &amp; Conditions (including Acceptable Use) for the Section 28 Video on Demand Portal."
+            Text="I agree to the Terms &amp; Conditions (including Acceptable Use) for the Pre-Recorded Evidence Service."
             Value="7/03/2024"
             SelectByDefault="false"
           />

--- a/b2c/custom_policies/dev/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkBase.xml
@@ -614,7 +614,6 @@
             <OutputClaim ClaimTypeReferenceId="tenantId" PartnerClaimType="tid" />
             <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />
             <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />
-            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="upn" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="localAccountAuthentication" />
           </OutputClaims>
@@ -659,7 +658,6 @@
             <!-- Required claims -->
             <PersistedClaim ClaimTypeReferenceId="email" PartnerClaimType="signInNames.emailAddress" />
             <PersistedClaim ClaimTypeReferenceId="newPassword" PartnerClaimType="password" />
-            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />
             <PersistedClaim ClaimTypeReferenceId="passwordPolicies" DefaultValue="DisablePasswordExpiration" />
 
             <PersistedClaim
@@ -700,7 +698,6 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
             <OutputClaim ClaimTypeReferenceId="accountEnabled" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
@@ -780,7 +777,6 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
             <OutputClaim ClaimTypeReferenceId="givenName" />
             <OutputClaim ClaimTypeReferenceId="surname" />
@@ -834,7 +830,6 @@
                  these values, or if the claim did not appear in the OutputClaims section of the IDP.
                  In addition, if a claim is not in the InputClaims section, but it is in the OutputClaims section, then its
                  value will not be prefilled, but the user will still be prompted for it (with an empty value). -->
-            <InputClaim ClaimTypeReferenceId="displayName" />
             <InputClaim ClaimTypeReferenceId="givenName" />
             <InputClaim ClaimTypeReferenceId="surname" />
           </InputClaims>
@@ -849,7 +844,6 @@
             <!-- Optional claims. These claims are collected from the user and can be modified. If a claim is to be persisted in the directory after having been
                  collected from the user, it needs to be added as a PersistedClaim in the ValidationTechnicalProfile referenced below, i.e.
                  in AAD-UserWriteUsingAlternativeSecurityId. -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
             <OutputClaim ClaimTypeReferenceId="givenName" />
             <OutputClaim ClaimTypeReferenceId="surname" />
           </OutputClaims>
@@ -923,7 +917,6 @@
             <OutputClaim ClaimTypeReferenceId="newUser" />
 
             <!-- Optional claims, to be collected from the user -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
             <OutputClaim ClaimTypeReferenceId="givenName" />
             <OutputClaim ClaimTypeReferenceId="surName" />
 
@@ -1167,7 +1160,6 @@
       <TechnicalProfile Id="AAD-UserReadUsingObjectId-CheckRefreshTokenDate">
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="refreshTokensValidFromDateTime" />
-          <OutputClaim ClaimTypeReferenceId="displayName" />
         </OutputClaims>
         <OutputClaimsTransformations>
           <OutputClaimsTransformation ReferenceId="AssertRefreshTokenIssuedLaterThanValidFromDate" />

--- a/b2c/custom_policies/dev/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkBase.xml
@@ -612,8 +612,8 @@
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="oid" />
             <OutputClaim ClaimTypeReferenceId="tenantId" PartnerClaimType="tid" />
-            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />
-            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />-->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="upn" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="localAccountAuthentication" />
           </OutputClaims>
@@ -666,8 +666,8 @@
             />
 
             <!-- Optional claims. -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" />
@@ -754,8 +754,8 @@
             />
 
             <!-- Optional claims -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -778,8 +778,8 @@
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -830,8 +830,8 @@
                  these values, or if the claim did not appear in the OutputClaims section of the IDP.
                  In addition, if a claim is not in the InputClaims section, but it is in the OutputClaims section, then its
                  value will not be prefilled, but the user will still be prompted for it (with an empty value). -->
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- These claims are not shown to the user because their value is obtained through the "ValidationTechnicalProfiles"
@@ -844,8 +844,8 @@
             <!-- Optional claims. These claims are collected from the user and can be modified. If a claim is to be persisted in the directory after having been
                  collected from the user, it needs to be added as a PersistedClaim in the ValidationTechnicalProfile referenced below, i.e.
                  in AAD-UserWriteUsingAlternativeSecurityId. -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <UseTechnicalProfileForSessionManagement ReferenceId="SM-SocialSignup" />
         </TechnicalProfile>
@@ -867,8 +867,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- Required claims -->
@@ -876,8 +876,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteProfileUsingObjectId" />
@@ -917,8 +917,8 @@
             <OutputClaim ClaimTypeReferenceId="newUser" />
 
             <!-- Optional claims, to be collected from the user -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surName" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" />-->
 
             <OutputClaim ClaimTypeReferenceId="TnCs" Required="true" />
           </OutputClaims>

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -164,8 +164,8 @@
             <!-- The Below claims are what will be returned on the UserInfo Endpoint if in the Claims Bag-->
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="objectId" />
-              <InputClaim ClaimTypeReferenceId="givenName" />
-              <InputClaim ClaimTypeReferenceId="surname" />
+<!--              <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--              <InputClaim ClaimTypeReferenceId="surname" />-->
               <InputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             </InputClaims>
           </TechnicalProfile>

--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -166,7 +166,6 @@
               <InputClaim ClaimTypeReferenceId="objectId" />
               <InputClaim ClaimTypeReferenceId="givenName" />
               <InputClaim ClaimTypeReferenceId="surname" />
-              <InputClaim ClaimTypeReferenceId="displayName" />
               <InputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             </InputClaims>
           </TechnicalProfile>
@@ -191,8 +190,7 @@
               <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
               <!-- Optional claims to read from the access token. -->
               <!-- <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name"/>
-                <OutputClaim ClaimTypeReferenceId="surname" PartnerClaimType="family_name"/>
-                <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name"/> -->
+                <OutputClaim ClaimTypeReferenceId="surname" PartnerClaimType="family_name"/> -->
             </OutputClaims>
           </TechnicalProfile>
           <TechnicalProfile Id="login-NonInteractive">

--- a/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
@@ -75,7 +75,7 @@
           <LocalizedString
             ElementType="UxElement"
             StringId="local_intro_generic"
-          >Sign in with your {0}</LocalizedString>
+          >Sign in</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="password"

--- a/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
@@ -175,12 +175,12 @@
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="DisplayName"
-          >New Password</LocalizedString>
+          >Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="UserHelpText"
-          >Enter new password</LocalizedString>
+          >Enter password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
@@ -190,12 +190,12 @@
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="DisplayName"
-          >Confirm New Password</LocalizedString>
+          >Confirm Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="UserHelpText"
-          >Confirm new password</LocalizedString>
+          >Confirm password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"

--- a/b2c/custom_policies/prod/SignUpOrSignin.xml
+++ b/b2c/custom_policies/prod/SignUpOrSignin.xml
@@ -53,9 +53,9 @@
       <DisplayName>PolicyProfile</DisplayName>
       <Protocol Name="OpenIdConnect" />
       <OutputClaims>
-        <OutputClaim ClaimTypeReferenceId="displayName" />
-        <OutputClaim ClaimTypeReferenceId="givenName" />
-        <OutputClaim ClaimTypeReferenceId="surname" />
+<!--        <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="surname" />-->
         <OutputClaim ClaimTypeReferenceId="email" />
         <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />

--- a/b2c/custom_policies/prod/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkBase.xml
@@ -612,9 +612,9 @@
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="oid" />
             <OutputClaim ClaimTypeReferenceId="tenantId" PartnerClaimType="tid" />
-            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />
-            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />
-            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />-->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="upn" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="localAccountAuthentication" />
           </OutputClaims>
@@ -659,7 +659,7 @@
             <!-- Required claims -->
             <PersistedClaim ClaimTypeReferenceId="email" PartnerClaimType="signInNames.emailAddress" />
             <PersistedClaim ClaimTypeReferenceId="newPassword" PartnerClaimType="password" />
-            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />
+<!--            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />-->
             <PersistedClaim ClaimTypeReferenceId="passwordPolicies" DefaultValue="DisablePasswordExpiration" />
 
             <PersistedClaim
@@ -668,8 +668,8 @@
             />
 
             <!-- Optional claims. -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" />
@@ -700,7 +700,7 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="accountEnabled" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
@@ -757,8 +757,8 @@
             />
 
             <!-- Optional claims -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -780,10 +780,10 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="otherMails" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -834,9 +834,9 @@
                  these values, or if the claim did not appear in the OutputClaims section of the IDP.
                  In addition, if a claim is not in the InputClaims section, but it is in the OutputClaims section, then its
                  value will not be prefilled, but the user will still be prompted for it (with an empty value). -->
-            <InputClaim ClaimTypeReferenceId="displayName" />
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- These claims are not shown to the user because their value is obtained through the "ValidationTechnicalProfiles"
@@ -849,9 +849,9 @@
             <!-- Optional claims. These claims are collected from the user and can be modified. If a claim is to be persisted in the directory after having been
                  collected from the user, it needs to be added as a PersistedClaim in the ValidationTechnicalProfile referenced below, i.e.
                  in AAD-UserWriteUsingAlternativeSecurityId. -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <UseTechnicalProfileForSessionManagement ReferenceId="SM-SocialSignup" />
         </TechnicalProfile>
@@ -873,8 +873,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- Required claims -->
@@ -882,8 +882,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteProfileUsingObjectId" />
@@ -923,9 +923,9 @@
             <OutputClaim ClaimTypeReferenceId="newUser" />
 
             <!-- Optional claims, to be collected from the user -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" />-->
 
             <OutputClaim ClaimTypeReferenceId="TnCs" Required="true" />
           </OutputClaims>
@@ -1167,7 +1167,7 @@
       <TechnicalProfile Id="AAD-UserReadUsingObjectId-CheckRefreshTokenDate">
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="refreshTokensValidFromDateTime" />
-          <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--          <OutputClaim ClaimTypeReferenceId="displayName" />-->
         </OutputClaims>
         <OutputClaimsTransformations>
           <OutputClaimsTransformation ReferenceId="AssertRefreshTokenIssuedLaterThanValidFromDate" />

--- a/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkExtensions.xml
@@ -164,9 +164,9 @@
             <!-- The Below claims are what will be returned on the UserInfo Endpoint if in the Claims Bag-->
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="objectId" />
-              <InputClaim ClaimTypeReferenceId="givenName" />
-              <InputClaim ClaimTypeReferenceId="surname" />
-              <InputClaim ClaimTypeReferenceId="displayName" />
+<!--              <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--              <InputClaim ClaimTypeReferenceId="surname" />-->
+<!--              <InputClaim ClaimTypeReferenceId="displayName" />-->
               <InputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             </InputClaims>
           </TechnicalProfile>

--- a/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
@@ -175,7 +175,7 @@
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="DisplayName"
-          >New Password</LocalizedString>
+          >Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
@@ -190,7 +190,7 @@
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="DisplayName"
-          >Confirm New Password</LocalizedString>
+          >Confirm Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"

--- a/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
@@ -75,7 +75,7 @@
           <LocalizedString
             ElementType="UxElement"
             StringId="local_intro_generic"
-          >Sign in with your {0}</LocalizedString>
+          >Sign in</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="password"

--- a/b2c/custom_policies/stg/SignUpOrSignin.xml
+++ b/b2c/custom_policies/stg/SignUpOrSignin.xml
@@ -53,9 +53,9 @@
       <DisplayName>PolicyProfile</DisplayName>
       <Protocol Name="OpenIdConnect" />
       <OutputClaims>
-        <OutputClaim ClaimTypeReferenceId="displayName" />
-        <OutputClaim ClaimTypeReferenceId="givenName" />
-        <OutputClaim ClaimTypeReferenceId="surname" />
+<!--        <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="surname" />-->
         <OutputClaim ClaimTypeReferenceId="email" />
         <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />

--- a/b2c/custom_policies/stg/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkBase.xml
@@ -612,9 +612,9 @@
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="oid" />
             <OutputClaim ClaimTypeReferenceId="tenantId" PartnerClaimType="tid" />
-            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />
-            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />
-            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />-->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="upn" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="localAccountAuthentication" />
           </OutputClaims>
@@ -659,7 +659,7 @@
             <!-- Required claims -->
             <PersistedClaim ClaimTypeReferenceId="email" PartnerClaimType="signInNames.emailAddress" />
             <PersistedClaim ClaimTypeReferenceId="newPassword" PartnerClaimType="password" />
-            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />
+<!--            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />-->
             <PersistedClaim ClaimTypeReferenceId="passwordPolicies" DefaultValue="DisablePasswordExpiration" />
 
             <PersistedClaim
@@ -668,8 +668,8 @@
             />
 
             <!-- Optional claims. -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" />
@@ -700,7 +700,7 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="accountEnabled" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
@@ -757,8 +757,8 @@
             />
 
             <!-- Optional claims -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -780,10 +780,10 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="otherMails" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -834,9 +834,9 @@
                  these values, or if the claim did not appear in the OutputClaims section of the IDP.
                  In addition, if a claim is not in the InputClaims section, but it is in the OutputClaims section, then its
                  value will not be prefilled, but the user will still be prompted for it (with an empty value). -->
-            <InputClaim ClaimTypeReferenceId="displayName" />
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- These claims are not shown to the user because their value is obtained through the "ValidationTechnicalProfiles"
@@ -849,9 +849,9 @@
             <!-- Optional claims. These claims are collected from the user and can be modified. If a claim is to be persisted in the directory after having been
                  collected from the user, it needs to be added as a PersistedClaim in the ValidationTechnicalProfile referenced below, i.e.
                  in AAD-UserWriteUsingAlternativeSecurityId. -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <UseTechnicalProfileForSessionManagement ReferenceId="SM-SocialSignup" />
         </TechnicalProfile>
@@ -873,8 +873,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- Required claims -->
@@ -882,8 +882,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteProfileUsingObjectId" />
@@ -923,9 +923,9 @@
             <OutputClaim ClaimTypeReferenceId="newUser" />
 
             <!-- Optional claims, to be collected from the user -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" />-->
 
             <OutputClaim ClaimTypeReferenceId="TnCs" Required="true" />
           </OutputClaims>
@@ -1167,7 +1167,7 @@
       <TechnicalProfile Id="AAD-UserReadUsingObjectId-CheckRefreshTokenDate">
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="refreshTokensValidFromDateTime" />
-          <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--          <OutputClaim ClaimTypeReferenceId="displayName" />-->
         </OutputClaims>
         <OutputClaimsTransformations>
           <OutputClaimsTransformation ReferenceId="AssertRefreshTokenIssuedLaterThanValidFromDate" />

--- a/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
@@ -164,9 +164,9 @@
             <!-- The Below claims are what will be returned on the UserInfo Endpoint if in the Claims Bag-->
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="objectId" />
-              <InputClaim ClaimTypeReferenceId="givenName" />
-              <InputClaim ClaimTypeReferenceId="surname" />
-              <InputClaim ClaimTypeReferenceId="displayName" />
+<!--              <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--              <InputClaim ClaimTypeReferenceId="surname" />-->
+<!--              <InputClaim ClaimTypeReferenceId="displayName" />-->
               <InputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             </InputClaims>
           </TechnicalProfile>

--- a/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
@@ -175,7 +175,7 @@
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="DisplayName"
-          >New Password</LocalizedString>
+          >Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
@@ -190,7 +190,7 @@
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="DisplayName"
-          >Confirm New Password</LocalizedString>
+          >Confirm Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"

--- a/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
@@ -75,7 +75,7 @@
           <LocalizedString
             ElementType="UxElement"
             StringId="local_intro_generic"
-          >Sign in with your {0}</LocalizedString>
+          >Sign in</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="password"

--- a/b2c/custom_policies/test/SignUpOrSignin.xml
+++ b/b2c/custom_policies/test/SignUpOrSignin.xml
@@ -54,9 +54,9 @@
       <DisplayName>PolicyProfile</DisplayName>
       <Protocol Name="OpenIdConnect" />
       <OutputClaims>
-        <OutputClaim ClaimTypeReferenceId="displayName" />
-        <OutputClaim ClaimTypeReferenceId="givenName" />
-        <OutputClaim ClaimTypeReferenceId="surname" />
+<!--        <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--        <OutputClaim ClaimTypeReferenceId="surname" />-->
         <OutputClaim ClaimTypeReferenceId="email" />
         <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />

--- a/b2c/custom_policies/test/TrustFrameworkBase.xml
+++ b/b2c/custom_policies/test/TrustFrameworkBase.xml
@@ -612,9 +612,9 @@
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="oid" />
             <OutputClaim ClaimTypeReferenceId="tenantId" PartnerClaimType="tid" />
-            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />
-            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />
-            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="given_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" PartnerClaimType="family_name" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" PartnerClaimType="name" />-->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="upn" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="localAccountAuthentication" />
           </OutputClaims>
@@ -659,7 +659,7 @@
             <!-- Required claims -->
             <PersistedClaim ClaimTypeReferenceId="email" PartnerClaimType="signInNames.emailAddress" />
             <PersistedClaim ClaimTypeReferenceId="newPassword" PartnerClaimType="password" />
-            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />
+<!--            <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />-->
             <PersistedClaim ClaimTypeReferenceId="passwordPolicies" DefaultValue="DisablePasswordExpiration" />
 
             <PersistedClaim
@@ -668,8 +668,8 @@
             />
 
             <!-- Optional claims. -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="objectId" />
@@ -700,7 +700,7 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="accountEnabled" />
             <OutputClaim ClaimTypeReferenceId="otherMails" />
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
@@ -757,8 +757,8 @@
             />
 
             <!-- Optional claims -->
-            <PersistedClaim ClaimTypeReferenceId="givenName" />
-            <PersistedClaim ClaimTypeReferenceId="surname" />
+<!--            <PersistedClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <PersistedClaim ClaimTypeReferenceId="surname" />-->
           </PersistedClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -780,10 +780,10 @@
 
             <!-- Optional claims -->
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
-            <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
             <OutputClaim ClaimTypeReferenceId="otherMails" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -834,9 +834,9 @@
                  these values, or if the claim did not appear in the OutputClaims section of the IDP.
                  In addition, if a claim is not in the InputClaims section, but it is in the OutputClaims section, then its
                  value will not be prefilled, but the user will still be prompted for it (with an empty value). -->
-            <InputClaim ClaimTypeReferenceId="displayName" />
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- These claims are not shown to the user because their value is obtained through the "ValidationTechnicalProfiles"
@@ -849,9 +849,9 @@
             <!-- Optional claims. These claims are collected from the user and can be modified. If a claim is to be persisted in the directory after having been
                  collected from the user, it needs to be added as a PersistedClaim in the ValidationTechnicalProfile referenced below, i.e.
                  in AAD-UserWriteUsingAlternativeSecurityId. -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <UseTechnicalProfileForSessionManagement ReferenceId="SM-SocialSignup" />
         </TechnicalProfile>
@@ -873,8 +873,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <InputClaim ClaimTypeReferenceId="givenName" />
-            <InputClaim ClaimTypeReferenceId="surname" />
+<!--            <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <InputClaim ClaimTypeReferenceId="surname" />-->
           </InputClaims>
           <OutputClaims>
             <!-- Required claims -->
@@ -882,8 +882,8 @@
 
             <!-- Optional claims. These claims are collected from the user and can be modified. Any claim added here should be updated in the
                  ValidationTechnicalProfile referenced below so it can be written to directory after being updated by the user, i.e. AAD-UserWriteProfileUsingObjectId. -->
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surname" />
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surname" />-->
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteProfileUsingObjectId" />
@@ -923,9 +923,9 @@
             <OutputClaim ClaimTypeReferenceId="newUser" />
 
             <!-- Optional claims, to be collected from the user -->
-            <OutputClaim ClaimTypeReferenceId="displayName" />
-            <OutputClaim ClaimTypeReferenceId="givenName" />
-            <OutputClaim ClaimTypeReferenceId="surName" />
+<!--            <OutputClaim ClaimTypeReferenceId="displayName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="givenName" />-->
+<!--            <OutputClaim ClaimTypeReferenceId="surName" />-->
 
             <OutputClaim ClaimTypeReferenceId="TnCs" Required="true" />
           </OutputClaims>
@@ -1167,7 +1167,7 @@
       <TechnicalProfile Id="AAD-UserReadUsingObjectId-CheckRefreshTokenDate">
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="refreshTokensValidFromDateTime" />
-          <OutputClaim ClaimTypeReferenceId="displayName" />
+<!--          <OutputClaim ClaimTypeReferenceId="displayName" />-->
         </OutputClaims>
         <OutputClaimsTransformations>
           <OutputClaimsTransformation ReferenceId="AssertRefreshTokenIssuedLaterThanValidFromDate" />

--- a/b2c/custom_policies/test/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/test/TrustFrameworkExtensions.xml
@@ -164,9 +164,9 @@
             <!-- The Below claims are what will be returned on the UserInfo Endpoint if in the Claims Bag-->
             <InputClaims>
               <InputClaim ClaimTypeReferenceId="objectId" />
-              <InputClaim ClaimTypeReferenceId="givenName" />
-              <InputClaim ClaimTypeReferenceId="surname" />
-              <InputClaim ClaimTypeReferenceId="displayName" />
+<!--              <InputClaim ClaimTypeReferenceId="givenName" />-->
+<!--              <InputClaim ClaimTypeReferenceId="surname" />-->
+<!--              <InputClaim ClaimTypeReferenceId="displayName" />-->
               <InputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
             </InputClaims>
           </TechnicalProfile>

--- a/b2c/custom_policies/test/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/test/TrustFrameworkLocalization.xml
@@ -175,7 +175,7 @@
             ElementType="ClaimType"
             ElementId="newPassword"
             StringId="DisplayName"
-          >New Password</LocalizedString>
+          >Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="newPassword"
@@ -190,7 +190,7 @@
             ElementType="ClaimType"
             ElementId="reenterPassword"
             StringId="DisplayName"
-          >Confirm New Password</LocalizedString>
+          >Confirm Password</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="reenterPassword"

--- a/b2c/custom_policies/test/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/test/TrustFrameworkLocalization.xml
@@ -75,7 +75,7 @@
           <LocalizedString
             ElementType="UxElement"
             StringId="local_intro_generic"
-          >Sign in with your {0}</LocalizedString>
+          >Sign in</LocalizedString>
           <LocalizedString
             ElementType="ClaimType"
             ElementId="password"

--- a/b2c/views/template.html
+++ b/b2c/views/template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title>Pre Recorded Evidence Account - GOV.UK</title>
+    <title>Pre-Recorded Evidence Account - GOV.UK</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">


### PR DESCRIPTION
### Change description ###
Remove given name, surname and display name fields
Update "Pre recorded" to be "Pre-Recorded"
Update Section 28 references to be Pre-Recorded Evidence Service
Change fields names form New Password to just Password on signup page

I've largely commented out rather than removed as I can imagine this going back in the future and having the initial config there may be of use to reference?

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
