### PR TITLE
Update b2c_custom_policies.yml

### DIFF
--- a/.github/workflows/b2c_custom_policies.yml
+++ b/.github/workflows/b2c_custom_policies.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Upload B2C Custom Policies to ${{ github.event.inputs.environment }}'
-        uses: azure-ad-b2c/deploy-trustframework-policy@v3
+        uses: azure-ad-b2c/deploy-trustframework-policy@v5
         with:
           folder: './b2c/custom_policies/${{ github.event.inputs.environment }}'
           files: 'TrustFrameworkBase.xml,TrustFrameworkLocalization.xml,TrustFrameworkExtensions.xml,SignUpOrSignin.xml,ProfileEdit.xml'

--- a/.github/workflows/b2c_custom_policies.yml
+++ b/.github/workflows/b2c_custom_policies.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Upload B2C Custom Policies to ${{ github.event.inputs.environment }}'
         uses: azure-ad-b2c/deploy-trustframework-policy@v3


### PR DESCRIPTION
### Change description ###
this is to update deprecated actions.

looks like we can't get away from the deprecated use of Node.js 12 for now though https://github.com/azure-ad-b2c/deploy-trustframework-policy/issues/129


**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
