### PR TITLE
Make B2C error messages more ambiguous

### DIFF
--- a/b2c/custom_policies/demo/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkLocalization.xml
@@ -118,11 +118,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -130,7 +130,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"
@@ -493,11 +493,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -505,7 +505,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"

--- a/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
@@ -118,11 +118,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -130,7 +130,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"
@@ -493,11 +493,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -505,7 +505,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"

--- a/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
@@ -118,11 +118,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -130,7 +130,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"
@@ -493,11 +493,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -505,7 +505,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"

--- a/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
@@ -118,11 +118,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -130,7 +130,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"
@@ -493,11 +493,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -505,7 +505,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"

--- a/b2c/custom_policies/test/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/test/TrustFrameworkLocalization.xml
@@ -118,11 +118,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -130,7 +130,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"
@@ -493,11 +493,11 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="ResourceOwnerFlowInvalidCredentials"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfInvalidPassword"
-          >Your password is incorrect.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfPasswordExpired"
@@ -505,7 +505,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalDoesNotExist"
-          >We can't seem to find your account.</LocalizedString>
+          >Incorrect email or password.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfOldPasswordUsed"


### PR DESCRIPTION
Currently B2C leaks that an email address is valid for our system, giving attackers 1 part of the puzzle as it were. This PR makes the error message ambiguous as to whether the users email or password is incorrect.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
