### PR TITLE
Set the B2C stg IdentityExperienceFramework ids

### DIFF
--- a/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkExtensions.xml
@@ -289,12 +289,7 @@
             <Preconditions>
               <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
                 <Value>objectId</Value>
-                <Value>a207a1b2-f39b-4e70-a211-bd7e26d7504e</Value> <!-- assume automated stg test user has valid phone -->
-                <Action>SkipThisOrchestrationStep</Action>
-              </Precondition>
-              <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
-                <Value>objectId</Value>
-                <Value>c9f5a9d8-f2c8-44ac-a9d7-f71b4f173742</Value> <!-- assume automated dev test user has valid phone -->
+                <Value>cd2ef111-05a1-41b7-a576-f2f05a6ffcd0</Value> <!-- assume automated test user has valid phone -->
                 <Action>SkipThisOrchestrationStep</Action>
               </Precondition>
               <Precondition Type="ClaimsExist" ExecuteActionsIf="true">

--- a/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkExtensions.xml
@@ -291,7 +291,12 @@
           <Preconditions>
             <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
               <Value>objectId</Value>
-              <Value>a207a1b2-f39b-4e70-a211-bd7e26d7504e</Value> <!-- assume automated test user has valid phone -->
+              <Value>a207a1b2-f39b-4e70-a211-bd7e26d7504e</Value> <!-- assume automated stg test user has valid phone -->
+              <Action>SkipThisOrchestrationStep</Action>
+            </Precondition>
+            <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+              <Value>objectId</Value>
+              <Value>c9f5a9d8-f2c8-44ac-a9d7-f71b4f173742</Value> <!-- assume automated dev test user has valid phone -->
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
             <Precondition Type="ClaimsExist" ExecuteActionsIf="true">


### PR DESCRIPTION
### Change description ###
IdentityExperienceFramework and ProxyIdentityExperienceFramework clientIds were the dev ones. I've updated to use the staging ones in the stg config.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
