### PR TITLE
Change message about existing account IDs

### DIFF
--- a/b2c/custom_policies/demo/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/demo/TrustFrameworkLocalization.xml
@@ -299,7 +299,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"
@@ -445,7 +445,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"

--- a/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/dev/TrustFrameworkLocalization.xml
@@ -299,7 +299,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"
@@ -445,7 +445,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"

--- a/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/prod/TrustFrameworkLocalization.xml
@@ -299,7 +299,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"
@@ -445,7 +445,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"

--- a/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/stg/TrustFrameworkLocalization.xml
@@ -299,7 +299,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"
@@ -445,7 +445,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"

--- a/b2c/custom_policies/test/TrustFrameworkLocalization.xml
+++ b/b2c/custom_policies/test/TrustFrameworkLocalization.xml
@@ -299,7 +299,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"
@@ -445,7 +445,7 @@
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfClaimsPrincipalAlreadyExists"
-          >A user with the specified ID already exists. Please choose a different one.</LocalizedString>
+          >There is an issue with your credentials, or you are already registered. Please check and retry.</LocalizedString>
           <LocalizedString
             ElementType="ErrorMessage"
             StringId="UserMessageIfIncorrectPattern"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[S28-2930](https://tools.hmcts.net/jira/browse/S28-2930)

### Change description ###

Replace error message of "A user with the specified ID already exists. Please choose a different one." with "There is an issue with your credentials, or you are already registered. Please check and retry." as requested after ITHC.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
