### PR TITLE
Remove bootstrap trigger and install hardenning requirements ourselves

### DIFF
--- a/scripts/edit-init.ps1
+++ b/scripts/edit-init.ps1
@@ -6,6 +6,15 @@ $currentPath = [Environment]::GetEnvironmentVariable("Path", "Machine")
 
 Start-Sleep -Seconds 5
 
+# Install platform required packages and modules from
+# https://raw.githubusercontent.com/hmcts/CIS-harderning/master/windows-install.ps1
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -force
+Install-Module -Name AuditPolicyDsc -force
+Install-Module -Name SecurityPolicyDsc -force
+Install-Module -Name NetworkingDsc -force
+Install-Module -Name PSDesiredStateConfiguration -force
+
+# Install PRE specific requirements
 choco feature enable -n allowGlobalConfirmation;
 choco install ffmpeg;
 choco install microsoftazurestorageexplorer;

--- a/vm-edit.tf
+++ b/vm-edit.tf
@@ -49,9 +49,9 @@ module "edit_vm" {
   dynatrace_tenant_id = var.tenant_id
   dynatrace_token     = try(data.azurerm_key_vault_secret.dynatrace-token.value, null)
 
-  run_command                  = true
-  rc_script_file               = "scripts/windows_run_script.ps1"
-  custom_script_extension_name = "HMCTSVMBootstrap"
+#   run_command                  = false
+#   rc_script_file               = "scripts/windows_run_script.ps1"
+#   custom_script_extension_name = "HMCTSVMBootstrap"
   tags                         = var.common_tags
 
 }

--- a/vm-edit.tf
+++ b/vm-edit.tf
@@ -49,11 +49,8 @@ module "edit_vm" {
   dynatrace_tenant_id = var.tenant_id
   dynatrace_token     = try(data.azurerm_key_vault_secret.dynatrace-token.value, null)
 
-  #   run_command                  = false
-  #   rc_script_file               = "scripts/windows_run_script.ps1"
-  #   custom_script_extension_name = "HMCTSVMBootstrap"
-  tags = var.common_tags
-
+  run_command                  = false
+  tags                         = var.common_tags
 }
 
 locals {

--- a/vm-edit.tf
+++ b/vm-edit.tf
@@ -49,8 +49,8 @@ module "edit_vm" {
   dynatrace_tenant_id = var.tenant_id
   dynatrace_token     = try(data.azurerm_key_vault_secret.dynatrace-token.value, null)
 
-  run_command                  = false
-  tags                         = var.common_tags
+  run_command = false
+  tags        = var.common_tags
 }
 
 locals {

--- a/vm-edit.tf
+++ b/vm-edit.tf
@@ -49,10 +49,10 @@ module "edit_vm" {
   dynatrace_tenant_id = var.tenant_id
   dynatrace_token     = try(data.azurerm_key_vault_secret.dynatrace-token.value, null)
 
-#   run_command                  = false
-#   rc_script_file               = "scripts/windows_run_script.ps1"
-#   custom_script_extension_name = "HMCTSVMBootstrap"
-  tags                         = var.common_tags
+  #   run_command                  = false
+  #   rc_script_file               = "scripts/windows_run_script.ps1"
+  #   custom_script_extension_name = "HMCTSVMBootstrap"
+  tags = var.common_tags
 
 }
 


### PR DESCRIPTION
For some reason using the Bootstrap module is causing an additional CustomScriptExtension to be installed as well as our own and windows only supports a single instance of CustomScriptExtension