### PR TITLE
Enable read only access via JIT

### DIFF
--- a/postgres.tf
+++ b/postgres.tf
@@ -12,6 +12,9 @@ module "data_store_db_v14" {
 
   common_tags = var.common_tags
   name        = var.database_name
+
+  enable_read_only_group_access = true
+
   pgsql_databases = [
     {
       name : "pre-pdb-${var.env}"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-3809


### Change description ###
This enables read-only access via JIT 

When `enable_read_only_group_access` is set to true, a terraform script is run here https://github.com/hmcts/terraform-module-postgresql-flexible/blob/ac3d281af4947dc9c4ec2b3b9678409e11b3e146/pgsql-flexible-server.tf#L175

This gives 'Usage' (view) permissions to the DB Reader group

Example here: https://github.com/hmcts/terraform-module-postgresql-flexible/blob/ac3d281af4947dc9c4ec2b3b9678409e11b3e146/example/main.tf#L18
