### PR TITLE
S28-4202 - Adds blocking shared email addresses to regex

### DIFF
--- a/b2c/custom_policies/test/SignUpOrSignin.xml
+++ b/b2c/custom_policies/test/SignUpOrSignin.xml
@@ -19,7 +19,7 @@
       <ClaimType Id="email">
         <Restriction>
           <Pattern
-            RegularExpression="^(?!(admin|info|hello|contact|support|sales|office|help)@[a-zA-Z0-9.\-]+)[a-zA-Z0-9.!#$%&amp;'^_`{}~\-+]+@[^\s@]+(?&lt;!cjsm\.net)$"
+            RegularExpression="^(?!(admin|hello|contact|support|sales|office|help)@[a-zA-Z0-9.\-]+)[a-zA-Z0-9.!#$%&amp;'^_`{}~\-+]+@[^\s@]+(?&lt;!cjsm\.net)$"
             HelpText="cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, info, support etc.), are not supported. Please enter a valid email address."
           />
         </Restriction>

--- a/b2c/custom_policies/test/SignUpOrSignin.xml
+++ b/b2c/custom_policies/test/SignUpOrSignin.xml
@@ -19,8 +19,8 @@
       <ClaimType Id="email">
         <Restriction>
           <Pattern
-            RegularExpression="^[a-zA-Z0-9.!#$%&amp;'^_`{}~\-+]+@[^\s@]+(?&lt;!cjsm\.net)$"
-            HelpText="cjsm.net email addresses are not supported. Please enter a valid email address."
+            RegularExpression="^(?!(admin|info|hello|contact|support|sales|office|help)@[a-zA-Z0-9.\-]+)[a-zA-Z0-9.!#$%&amp;'^_`{}~\-+]+@[^\s@]+(?&lt;!cjsm\.net)$"
+            HelpText="cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, info, support etc.), are not supported. Please enter a valid email address."
           />
         </Restriction>
       </ClaimType>
@@ -33,7 +33,7 @@
             ElementType="ClaimType"
             ElementId="email"
             StringId="PatternHelpText"
-          >cjsm.net email addresses are not supported. Please enter a valid email address.</LocalizedString>
+          >cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, info, support etc.), are not supported. Please enter a valid email address.</LocalizedString>
         </LocalizedStrings>
       </LocalizedResources>
     </Localization>

--- a/b2c/custom_policies/test/SignUpOrSignin.xml
+++ b/b2c/custom_policies/test/SignUpOrSignin.xml
@@ -20,7 +20,7 @@
         <Restriction>
           <Pattern
             RegularExpression="^(?!(admin|hello|contact|support|sales|office|help)@[a-zA-Z0-9.\-]+)[a-zA-Z0-9.!#$%&amp;'^_`{}~\-+]+@[^\s@]+(?&lt;!cjsm\.net)$"
-            HelpText="cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, info, support etc.), are not supported. Please enter a valid email address."
+            HelpText="cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, support etc.), are not supported. Please enter a valid email address."
           />
         </Restriction>
       </ClaimType>
@@ -33,7 +33,7 @@
             ElementType="ClaimType"
             ElementId="email"
             StringId="PatternHelpText"
-          >cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, info, support etc.), are not supported. Please enter a valid email address.</LocalizedString>
+          >cjsm.net email addresses and shared email addresses, i.e. ones not specific to you (e.g. admin, support etc.), are not supported. Please enter a valid email address.</LocalizedString>
         </LocalizedStrings>
       </LocalizedResources>
     </Localization>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/S28-4202

### Change description ###

Adds a lookup to the regex to not allow certain shared email addresses - `(?!(admin|info|hello|contact|support|sales|office|help)@[a-zA-Z0-9.\-]+)`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
